### PR TITLE
feat: 認証機能の実装

### DIFF
--- a/__tests__/actions/auth.test.ts
+++ b/__tests__/actions/auth.test.ts
@@ -32,7 +32,8 @@ import { prisma } from '@/lib/prisma'
 import bcrypt from 'bcryptjs'
 import { signIn, signOut } from '@/lib/auth'
 
-const mockPrisma = prisma as jest.Mocked<typeof prisma>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockPrisma = prisma as any
 const mockBcrypt = bcrypt as jest.Mocked<typeof bcrypt>
 const mockSignIn = signIn as jest.MockedFunction<typeof signIn>
 const mockSignOut = signOut as jest.MockedFunction<typeof signOut>

--- a/__tests__/actions/auth.test.ts
+++ b/__tests__/actions/auth.test.ts
@@ -1,4 +1,4 @@
-import { signup, login } from '@/actions/auth'
+import { signup, login, logout } from '@/actions/auth'
 
 // Mock modules
 jest.mock('@/lib/prisma', () => ({
@@ -17,6 +17,7 @@ jest.mock('bcryptjs', () => ({
 
 jest.mock('@/lib/auth', () => ({
   signIn: jest.fn(),
+  signOut: jest.fn(),
 }))
 
 // Mock next/navigation redirect
@@ -29,11 +30,12 @@ jest.mock('next/navigation', () => ({
 // Import mocks after jest.mock
 import { prisma } from '@/lib/prisma'
 import bcrypt from 'bcryptjs'
-import { signIn } from '@/lib/auth'
+import { signIn, signOut } from '@/lib/auth'
 
 const mockPrisma = prisma as jest.Mocked<typeof prisma>
 const mockBcrypt = bcrypt as jest.Mocked<typeof bcrypt>
 const mockSignIn = signIn as jest.MockedFunction<typeof signIn>
+const mockSignOut = signOut as jest.MockedFunction<typeof signOut>
 
 describe('signup action', () => {
   beforeEach(() => {
@@ -155,5 +157,19 @@ describe('login action', () => {
     expect(result.success).toBe(false)
     expect(result.error).toBeDefined()
     expect(mockSignIn).not.toHaveBeenCalled()
+  })
+})
+
+describe('logout action', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should sign out and redirect to login', async () => {
+    mockSignOut.mockResolvedValue(undefined)
+
+    await expect(logout()).rejects.toThrow('REDIRECT:/login')
+
+    expect(mockSignOut).toHaveBeenCalledWith({ redirect: false })
   })
 })

--- a/__tests__/actions/auth.test.ts
+++ b/__tests__/actions/auth.test.ts
@@ -1,0 +1,159 @@
+import { signup, login } from '@/actions/auth'
+
+// Mock modules
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+    },
+  },
+}))
+
+jest.mock('bcryptjs', () => ({
+  hash: jest.fn(),
+  compare: jest.fn(),
+}))
+
+jest.mock('@/lib/auth', () => ({
+  signIn: jest.fn(),
+}))
+
+// Mock next/navigation redirect
+jest.mock('next/navigation', () => ({
+  redirect: jest.fn((url: string) => {
+    throw new Error(`REDIRECT:${url}`)
+  }),
+}))
+
+// Import mocks after jest.mock
+import { prisma } from '@/lib/prisma'
+import bcrypt from 'bcryptjs'
+import { signIn } from '@/lib/auth'
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>
+const mockBcrypt = bcrypt as jest.Mocked<typeof bcrypt>
+const mockSignIn = signIn as jest.MockedFunction<typeof signIn>
+
+describe('signup action', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should create a new user and sign in', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue(null)
+    mockBcrypt.hash.mockResolvedValue('hashed_password' as never)
+    mockPrisma.user.create.mockResolvedValue({
+      id: 'user-1',
+      email: 'test@example.com',
+      name: null,
+      password: 'hashed_password',
+      emailVerified: null,
+      image: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    mockSignIn.mockResolvedValue(undefined)
+
+    await expect(signup({
+      email: 'test@example.com',
+      password: 'password123',
+      confirmPassword: 'password123',
+    })).rejects.toThrow('REDIRECT:/todos')
+
+    expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({
+      where: { email: 'test@example.com' },
+    })
+    expect(mockBcrypt.hash).toHaveBeenCalledWith('password123', 12)
+    expect(mockPrisma.user.create).toHaveBeenCalledWith({
+      data: {
+        email: 'test@example.com',
+        password: 'hashed_password',
+      },
+    })
+    expect(mockSignIn).toHaveBeenCalledWith('credentials', {
+      email: 'test@example.com',
+      password: 'password123',
+      redirect: false,
+    })
+  })
+
+  it('should return error if email already exists', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue({
+      id: 'existing-user',
+      email: 'existing@example.com',
+      name: null,
+      password: 'hashed_password',
+      emailVerified: null,
+      image: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    const result = await signup({
+      email: 'existing@example.com',
+      password: 'password123',
+      confirmPassword: 'password123',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('このメールアドレスは既に登録されています')
+    expect(mockPrisma.user.create).not.toHaveBeenCalled()
+  })
+
+  it('should return error for invalid input', async () => {
+    const result = await signup({
+      email: 'invalid-email',
+      password: 'short',
+      confirmPassword: 'short',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBeDefined()
+    expect(mockPrisma.user.findUnique).not.toHaveBeenCalled()
+  })
+})
+
+describe('login action', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should sign in with valid credentials', async () => {
+    mockSignIn.mockResolvedValue(undefined)
+
+    await expect(login({
+      email: 'test@example.com',
+      password: 'password123',
+    })).rejects.toThrow('REDIRECT:/todos')
+
+    expect(mockSignIn).toHaveBeenCalledWith('credentials', {
+      email: 'test@example.com',
+      password: 'password123',
+      redirect: false,
+    })
+  })
+
+  it('should return error for invalid credentials', async () => {
+    mockSignIn.mockRejectedValue(new Error('CredentialsSignin'))
+
+    const result = await login({
+      email: 'test@example.com',
+      password: 'wrongpassword',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('メールアドレスまたはパスワードが正しくありません')
+  })
+
+  it('should return error for invalid input', async () => {
+    const result = await login({
+      email: 'invalid-email',
+      password: '',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBeDefined()
+    expect(mockSignIn).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/app/login/page.test.tsx
+++ b/__tests__/app/login/page.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react'
+import LoginPage from '@/app/login/page'
+
+// Mock LoginForm component
+jest.mock('@/components/auth/LoginForm', () => ({
+  LoginForm: () => <div data-testid="login-form">Login Form Mock</div>,
+}))
+
+describe('LoginPage', () => {
+  it('should render the login page with title', () => {
+    render(<LoginPage />)
+
+    expect(screen.getByRole('heading', { name: 'ログイン' })).toBeInTheDocument()
+  })
+
+  it('should render the LoginForm component', () => {
+    render(<LoginPage />)
+
+    expect(screen.getByTestId('login-form')).toBeInTheDocument()
+  })
+
+  it('should have proper page structure', () => {
+    render(<LoginPage />)
+
+    const main = screen.getByRole('main')
+    expect(main).toBeInTheDocument()
+  })
+})

--- a/__tests__/app/page.test.tsx
+++ b/__tests__/app/page.test.tsx
@@ -19,16 +19,16 @@ describe('Home Page', () => {
     expect(screen.getByText('タスク管理を始める')).toBeInTheDocument()
   })
 
-  it('should render 新規登録 button', () => {
+  it('should render 新規登録 link', () => {
     render(<Home />)
-    const button = screen.getByRole('button', { name: '新規登録' })
-    expect(button).toBeInTheDocument()
+    const link = screen.getByRole('link', { name: '新規登録' })
+    expect(link).toHaveAttribute('href', '/signup')
   })
 
-  it('should render ログイン button', () => {
+  it('should render ログイン link', () => {
     render(<Home />)
-    const button = screen.getByRole('button', { name: 'ログイン' })
-    expect(button).toBeInTheDocument()
+    const link = screen.getByRole('link', { name: 'ログイン' })
+    expect(link).toHaveAttribute('href', '/login')
   })
 
   it('should have center alignment classes on main element', () => {

--- a/__tests__/app/signup/page.test.tsx
+++ b/__tests__/app/signup/page.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react'
+import SignupPage from '@/app/signup/page'
+
+// Mock SignupForm component
+jest.mock('@/components/auth/SignupForm', () => ({
+  SignupForm: () => <div data-testid="signup-form">Signup Form Mock</div>,
+}))
+
+describe('SignupPage', () => {
+  it('should render the signup page with title', () => {
+    render(<SignupPage />)
+
+    expect(screen.getByRole('heading', { name: '新規登録' })).toBeInTheDocument()
+  })
+
+  it('should render the SignupForm component', () => {
+    render(<SignupPage />)
+
+    expect(screen.getByTestId('signup-form')).toBeInTheDocument()
+  })
+
+  it('should have proper page structure', () => {
+    render(<SignupPage />)
+
+    const main = screen.getByRole('main')
+    expect(main).toBeInTheDocument()
+  })
+})

--- a/__tests__/app/todos/page.test.tsx
+++ b/__tests__/app/todos/page.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react'
+import TodosPage from '@/app/todos/page'
+
+// Mock the auth function
+jest.mock('@/lib/auth', () => ({
+  auth: jest.fn().mockResolvedValue({
+    user: {
+      id: 'user-1',
+      email: 'test@example.com',
+      name: 'Test User',
+    },
+  }),
+}))
+
+describe('TodosPage', () => {
+  it('should render the todos page with title', async () => {
+    render(await TodosPage())
+
+    expect(screen.getByRole('heading', { name: 'ToDo一覧' })).toBeInTheDocument()
+  })
+
+  it('should have proper page structure', async () => {
+    render(await TodosPage())
+
+    const main = screen.getByRole('main')
+    expect(main).toBeInTheDocument()
+  })
+
+  it('should display placeholder message', async () => {
+    render(await TodosPage())
+
+    expect(screen.getByText(/ToDoはまだありません/)).toBeInTheDocument()
+  })
+})

--- a/__tests__/components/Header.test.tsx
+++ b/__tests__/components/Header.test.tsx
@@ -1,38 +1,93 @@
 import { render, screen } from '@testing-library/react'
 import { Header } from '@/components/Header'
 
+// Mock the auth function
+const mockAuth = jest.fn()
+jest.mock('@/lib/auth', () => ({
+  auth: () => mockAuth(),
+}))
+
+// Mock the logout action
+jest.mock('@/actions/auth', () => ({
+  logout: jest.fn(),
+}))
+
 describe('Header', () => {
-  it('should render logo with icon', () => {
-    render(<Header />)
-    const icon = screen.getByTestId('header-logo-icon')
-    expect(icon).toBeInTheDocument()
+  beforeEach(() => {
+    mockAuth.mockReset()
   })
 
-  it('should render logo text', () => {
-    render(<Header />)
-    expect(screen.getByText('ToDoアプリ')).toBeInTheDocument()
+  describe('when not authenticated', () => {
+    beforeEach(() => {
+      mockAuth.mockResolvedValue(null)
+    })
+
+    it('should render logo with icon', async () => {
+      render(await Header())
+      const icon = screen.getByTestId('header-logo-icon')
+      expect(icon).toBeInTheDocument()
+    })
+
+    it('should render logo text', async () => {
+      render(await Header())
+      expect(screen.getByText('ToDoアプリ')).toBeInTheDocument()
+    })
+
+    it('should have logo as a link to /', async () => {
+      render(await Header())
+      const link = screen.getByRole('link', { name: /ToDoアプリ/i })
+      expect(link).toHaveAttribute('href', '/')
+    })
+
+    it('should render 新規登録 link', async () => {
+      render(await Header())
+      const link = screen.getByRole('link', { name: '新規登録' })
+      expect(link).toHaveAttribute('href', '/signup')
+    })
+
+    it('should render ログイン link', async () => {
+      render(await Header())
+      const link = screen.getByRole('link', { name: 'ログイン' })
+      expect(link).toHaveAttribute('href', '/login')
+    })
+
+    it('should not render logout button', async () => {
+      render(await Header())
+      expect(screen.queryByRole('button', { name: 'ログアウト' })).not.toBeInTheDocument()
+    })
   })
 
-  it('should have logo as a link to /', () => {
-    render(<Header />)
-    const link = screen.getByRole('link', { name: /ToDoアプリ/i })
-    expect(link).toHaveAttribute('href', '/')
+  describe('when authenticated', () => {
+    beforeEach(() => {
+      mockAuth.mockResolvedValue({
+        user: {
+          id: 'user-1',
+          email: 'test@example.com',
+          name: 'Test User',
+        },
+      })
+    })
+
+    it('should render logout button', async () => {
+      render(await Header())
+      const button = screen.getByRole('button', { name: 'ログアウト' })
+      expect(button).toBeInTheDocument()
+    })
+
+    it('should not render signup link', async () => {
+      render(await Header())
+      expect(screen.queryByRole('link', { name: '新規登録' })).not.toBeInTheDocument()
+    })
+
+    it('should not render login link', async () => {
+      render(await Header())
+      expect(screen.queryByRole('link', { name: 'ログイン' })).not.toBeInTheDocument()
+    })
   })
 
-  it('should render 新規登録 button', () => {
-    render(<Header />)
-    const button = screen.getByRole('button', { name: '新規登録' })
-    expect(button).toBeInTheDocument()
-  })
-
-  it('should render ログイン button', () => {
-    render(<Header />)
-    const button = screen.getByRole('button', { name: 'ログイン' })
-    expect(button).toBeInTheDocument()
-  })
-
-  it('should have sticky class for fixed positioning', () => {
-    const { container } = render(<Header />)
+  it('should have sticky class for fixed positioning', async () => {
+    mockAuth.mockResolvedValue(null)
+    const { container } = render(await Header())
     const header = container.querySelector('header')
     expect(header).toHaveClass('sticky')
   })

--- a/__tests__/components/auth/LoginForm.test.tsx
+++ b/__tests__/components/auth/LoginForm.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { LoginForm } from '@/components/auth/LoginForm'
+
+// Mock the login action
+const mockLogin = jest.fn()
+jest.mock('@/actions/auth', () => ({
+  login: (...args: unknown[]) => mockLogin(...args),
+}))
+
+describe('LoginForm', () => {
+  beforeEach(() => {
+    mockLogin.mockReset()
+  })
+
+  it('should render all form fields', () => {
+    render(<LoginForm />)
+
+    expect(screen.getByLabelText('メールアドレス')).toBeInTheDocument()
+    expect(screen.getByLabelText('パスワード')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'ログイン' })).toBeInTheDocument()
+  })
+
+  it('should show validation error for invalid email', async () => {
+    render(<LoginForm />)
+
+    const emailInput = screen.getByLabelText('メールアドレス')
+    fireEvent.change(emailInput, { target: { value: 'invalid-email' } })
+
+    const passwordInput = screen.getByLabelText('パスワード')
+    fireEvent.change(passwordInput, { target: { value: 'password123' } })
+
+    const submitButton = screen.getByRole('button', { name: 'ログイン' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('有効なメールアドレスを入力してください')).toBeInTheDocument()
+    })
+  })
+
+  it('should show validation error for empty password', async () => {
+    render(<LoginForm />)
+
+    const emailInput = screen.getByLabelText('メールアドレス')
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } })
+
+    const submitButton = screen.getByRole('button', { name: 'ログイン' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('パスワードを入力してください')).toBeInTheDocument()
+    })
+  })
+
+  it('should call login action with form data on valid submission', async () => {
+    mockLogin.mockResolvedValue({ success: true })
+    render(<LoginForm />)
+
+    const emailInput = screen.getByLabelText('メールアドレス')
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } })
+
+    const passwordInput = screen.getByLabelText('パスワード')
+    fireEvent.change(passwordInput, { target: { value: 'password123' } })
+
+    const submitButton = screen.getByRole('button', { name: 'ログイン' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockLogin).toHaveBeenCalledWith({
+        email: 'test@example.com',
+        password: 'password123',
+      })
+    })
+  })
+
+  it('should display server error message', async () => {
+    mockLogin.mockResolvedValue({ success: false, error: 'メールアドレスまたはパスワードが正しくありません' })
+    render(<LoginForm />)
+
+    const emailInput = screen.getByLabelText('メールアドレス')
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } })
+
+    const passwordInput = screen.getByLabelText('パスワード')
+    fireEvent.change(passwordInput, { target: { value: 'wrongpassword' } })
+
+    const submitButton = screen.getByRole('button', { name: 'ログイン' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('メールアドレスまたはパスワードが正しくありません')).toBeInTheDocument()
+    })
+  })
+
+  it('should have a link to signup page', () => {
+    render(<LoginForm />)
+
+    const signupLink = screen.getByRole('link', { name: '新規登録' })
+    expect(signupLink).toHaveAttribute('href', '/signup')
+  })
+})

--- a/__tests__/components/auth/SignupForm.test.tsx
+++ b/__tests__/components/auth/SignupForm.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { SignupForm } from '@/components/auth/SignupForm'
+
+// Mock the signup action
+const mockSignup = jest.fn()
+jest.mock('@/actions/auth', () => ({
+  signup: (...args: unknown[]) => mockSignup(...args),
+}))
+
+describe('SignupForm', () => {
+  beforeEach(() => {
+    mockSignup.mockReset()
+  })
+
+  it('should render all form fields', () => {
+    render(<SignupForm />)
+
+    expect(screen.getByLabelText('メールアドレス')).toBeInTheDocument()
+    expect(screen.getByLabelText('パスワード')).toBeInTheDocument()
+    expect(screen.getByLabelText('パスワード（確認）')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '新規登録' })).toBeInTheDocument()
+  })
+
+  it('should show validation errors for empty fields', async () => {
+    render(<SignupForm />)
+
+    const submitButton = screen.getByRole('button', { name: '新規登録' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('有効なメールアドレスを入力してください')).toBeInTheDocument()
+    })
+  })
+
+  it('should show validation error for invalid email', async () => {
+    render(<SignupForm />)
+
+    const emailInput = screen.getByLabelText('メールアドレス')
+    fireEvent.change(emailInput, { target: { value: 'invalid-email' } })
+
+    const passwordInput = screen.getByLabelText('パスワード')
+    fireEvent.change(passwordInput, { target: { value: 'password123' } })
+
+    const confirmPasswordInput = screen.getByLabelText('パスワード（確認）')
+    fireEvent.change(confirmPasswordInput, { target: { value: 'password123' } })
+
+    const submitButton = screen.getByRole('button', { name: '新規登録' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('有効なメールアドレスを入力してください')).toBeInTheDocument()
+    })
+  })
+
+  it('should show validation error for short password', async () => {
+    render(<SignupForm />)
+
+    const emailInput = screen.getByLabelText('メールアドレス')
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } })
+
+    const passwordInput = screen.getByLabelText('パスワード')
+    fireEvent.change(passwordInput, { target: { value: 'short' } })
+
+    const confirmPasswordInput = screen.getByLabelText('パスワード（確認）')
+    fireEvent.change(confirmPasswordInput, { target: { value: 'short' } })
+
+    const submitButton = screen.getByRole('button', { name: '新規登録' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('パスワードは8文字以上で入力してください')).toBeInTheDocument()
+    })
+  })
+
+  it('should show validation error when passwords do not match', async () => {
+    render(<SignupForm />)
+
+    const emailInput = screen.getByLabelText('メールアドレス')
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } })
+
+    const passwordInput = screen.getByLabelText('パスワード')
+    fireEvent.change(passwordInput, { target: { value: 'password123' } })
+
+    const confirmPasswordInput = screen.getByLabelText('パスワード（確認）')
+    fireEvent.change(confirmPasswordInput, { target: { value: 'different123' } })
+
+    const submitButton = screen.getByRole('button', { name: '新規登録' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('パスワードが一致しません')).toBeInTheDocument()
+    })
+  })
+
+  it('should call signup action with form data on valid submission', async () => {
+    mockSignup.mockResolvedValue({ success: true })
+    render(<SignupForm />)
+
+    const emailInput = screen.getByLabelText('メールアドレス')
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } })
+
+    const passwordInput = screen.getByLabelText('パスワード')
+    fireEvent.change(passwordInput, { target: { value: 'password123' } })
+
+    const confirmPasswordInput = screen.getByLabelText('パスワード（確認）')
+    fireEvent.change(confirmPasswordInput, { target: { value: 'password123' } })
+
+    const submitButton = screen.getByRole('button', { name: '新規登録' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockSignup).toHaveBeenCalledWith({
+        email: 'test@example.com',
+        password: 'password123',
+        confirmPassword: 'password123',
+      })
+    })
+  })
+
+  it('should display server error message', async () => {
+    mockSignup.mockResolvedValue({ success: false, error: 'このメールアドレスは既に登録されています' })
+    render(<SignupForm />)
+
+    const emailInput = screen.getByLabelText('メールアドレス')
+    fireEvent.change(emailInput, { target: { value: 'existing@example.com' } })
+
+    const passwordInput = screen.getByLabelText('パスワード')
+    fireEvent.change(passwordInput, { target: { value: 'password123' } })
+
+    const confirmPasswordInput = screen.getByLabelText('パスワード（確認）')
+    fireEvent.change(confirmPasswordInput, { target: { value: 'password123' } })
+
+    const submitButton = screen.getByRole('button', { name: '新規登録' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('このメールアドレスは既に登録されています')).toBeInTheDocument()
+    })
+  })
+
+  it('should have a link to login page', () => {
+    render(<SignupForm />)
+
+    const loginLink = screen.getByRole('link', { name: 'ログイン' })
+    expect(loginLink).toHaveAttribute('href', '/login')
+  })
+})

--- a/__tests__/lib/validations/auth.test.ts
+++ b/__tests__/lib/validations/auth.test.ts
@@ -1,0 +1,97 @@
+import { signupSchema, loginSchema } from '@/lib/validations/auth'
+
+describe('signupSchema', () => {
+  it('should validate correct signup data', () => {
+    const validData = {
+      email: 'test@example.com',
+      password: 'password123',
+      confirmPassword: 'password123',
+    }
+    const result = signupSchema.safeParse(validData)
+    expect(result.success).toBe(true)
+  })
+
+  it('should reject invalid email', () => {
+    const invalidData = {
+      email: 'invalid-email',
+      password: 'password123',
+      confirmPassword: 'password123',
+    }
+    const result = signupSchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('email')
+    }
+  })
+
+  it('should reject password shorter than 8 characters', () => {
+    const invalidData = {
+      email: 'test@example.com',
+      password: 'short',
+      confirmPassword: 'short',
+    }
+    const result = signupSchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('password')
+    }
+  })
+
+  it('should reject when passwords do not match', () => {
+    const invalidData = {
+      email: 'test@example.com',
+      password: 'password123',
+      confirmPassword: 'different123',
+    }
+    const result = signupSchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('confirmPassword')
+    }
+  })
+
+  it('should reject empty email', () => {
+    const invalidData = {
+      email: '',
+      password: 'password123',
+      confirmPassword: 'password123',
+    }
+    const result = signupSchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('loginSchema', () => {
+  it('should validate correct login data', () => {
+    const validData = {
+      email: 'test@example.com',
+      password: 'password123',
+    }
+    const result = loginSchema.safeParse(validData)
+    expect(result.success).toBe(true)
+  })
+
+  it('should reject invalid email', () => {
+    const invalidData = {
+      email: 'invalid-email',
+      password: 'password123',
+    }
+    const result = loginSchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('email')
+    }
+  })
+
+  it('should reject empty password', () => {
+    const invalidData = {
+      email: 'test@example.com',
+      password: '',
+    }
+    const result = loginSchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('password')
+    }
+  })
+})

--- a/actions/auth.ts
+++ b/actions/auth.ts
@@ -36,11 +36,15 @@ export async function signup(data: SignupInput): Promise<AuthResult> {
     },
   })
 
-  await signIn('credentials', {
-    email,
-    password,
-    redirect: false,
-  })
+  try {
+    await signIn('credentials', {
+      email,
+      password,
+      redirect: false,
+    })
+  } catch {
+    return { success: false, error: 'ログインに失敗しました。再度お試しください。' }
+  }
 
   redirect('/todos')
 }

--- a/actions/auth.ts
+++ b/actions/auth.ts
@@ -1,0 +1,22 @@
+'use server'
+
+import type { SignupInput, LoginInput } from '@/lib/validations/auth'
+
+export type AuthResult = {
+  success: boolean
+  error?: string
+}
+
+export async function signup(_data: SignupInput): Promise<AuthResult> {
+  // Will be implemented
+  return { success: false, error: 'Not implemented' }
+}
+
+export async function login(_data: LoginInput): Promise<AuthResult> {
+  // Will be implemented
+  return { success: false, error: 'Not implemented' }
+}
+
+export async function logout(): Promise<void> {
+  // Will be implemented
+}

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from '@/lib/auth'
+
+export const { GET, POST } = handlers

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Header } from "@/components/Header";
+import { SessionProvider } from "@/components/SessionProvider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -28,8 +29,10 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <Header />
-        {children}
+        <SessionProvider>
+          <Header />
+          {children}
+        </SessionProvider>
       </body>
     </html>
   );

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,17 @@
+import { LoginForm } from '@/components/auth/LoginForm'
+
+export default function LoginPage() {
+  return (
+    <main className="flex min-h-[calc(100vh-64px)] items-center justify-center px-4">
+      <div className="w-full max-w-md space-y-6">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold">ログイン</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            アカウントにログインしてToDoを管理しましょう
+          </p>
+        </div>
+        <LoginForm />
+      </div>
+    </main>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import { CheckSquare } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 
@@ -12,8 +13,12 @@ export default function Home() {
         <p className="text-lg text-muted-foreground">タスク管理を始める</p>
       </div>
       <div className="flex items-center gap-4">
-        <Button variant="default" size="lg">新規登録</Button>
-        <Button variant="outline" size="lg">ログイン</Button>
+        <Button variant="default" size="lg" asChild>
+          <Link href="/signup">新規登録</Link>
+        </Button>
+        <Button variant="outline" size="lg" asChild>
+          <Link href="/login">ログイン</Link>
+        </Button>
       </div>
     </main>
   )

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,0 +1,17 @@
+import { SignupForm } from '@/components/auth/SignupForm'
+
+export default function SignupPage() {
+  return (
+    <main className="flex min-h-[calc(100vh-64px)] items-center justify-center px-4">
+      <div className="w-full max-w-md space-y-6">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold">新規登録</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            アカウントを作成してToDoを管理しましょう
+          </p>
+        </div>
+        <SignupForm />
+      </div>
+    </main>
+  )
+}

--- a/app/todos/page.tsx
+++ b/app/todos/page.tsx
@@ -1,0 +1,17 @@
+import { auth } from '@/lib/auth'
+
+export default async function TodosPage() {
+  const session = await auth()
+
+  return (
+    <main className="container mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold mb-6">ToDo一覧</h1>
+      <div className="text-center py-12 text-muted-foreground">
+        <p>ToDoはまだありません</p>
+        <p className="text-sm mt-2">
+          ようこそ、{session?.user?.email}さん
+        </p>
+      </div>
+    </main>
+  )
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,8 +1,12 @@
 import Link from 'next/link'
 import { CheckSquare } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { auth } from '@/lib/auth'
+import { logout } from '@/actions/auth'
 
-export function Header() {
+export async function Header() {
+  const session = await auth()
+
   return (
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="container mx-auto flex h-16 items-center justify-between px-4">
@@ -11,8 +15,22 @@ export function Header() {
           <span className="text-xl font-bold">ToDoアプリ</span>
         </Link>
         <div className="flex items-center gap-2">
-          <Button variant="default">新規登録</Button>
-          <Button variant="outline">ログイン</Button>
+          {session ? (
+            <form action={logout}>
+              <Button type="submit" variant="outline">
+                ログアウト
+              </Button>
+            </form>
+          ) : (
+            <>
+              <Button variant="default" asChild>
+                <Link href="/signup">新規登録</Link>
+              </Button>
+              <Button variant="outline" asChild>
+                <Link href="/login">ログイン</Link>
+              </Button>
+            </>
+          )}
         </div>
       </div>
     </header>

--- a/components/SessionProvider.tsx
+++ b/components/SessionProvider.tsx
@@ -1,9 +1,10 @@
 'use client'
 
+import type { ReactNode } from 'react'
 import { SessionProvider as NextAuthSessionProvider } from 'next-auth/react'
 
 interface Props {
-  children: React.ReactNode
+  children: ReactNode
 }
 
 export function SessionProvider({ children }: Props) {

--- a/components/SessionProvider.tsx
+++ b/components/SessionProvider.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import { SessionProvider as NextAuthSessionProvider } from 'next-auth/react'
+
+interface Props {
+  children: React.ReactNode
+}
+
+export function SessionProvider({ children }: Props) {
+  return <NextAuthSessionProvider>{children}</NextAuthSessionProvider>
+}

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import Link from 'next/link'
+import { loginSchema, type LoginInput } from '@/lib/validations/auth'
+import { login } from '@/actions/auth'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+
+export function LoginForm() {
+  const [serverError, setServerError] = useState<string | null>(null)
+
+  const form = useForm<LoginInput>({
+    resolver: zodResolver(loginSchema),
+    defaultValues: {
+      email: '',
+      password: '',
+    },
+  })
+
+  const onSubmit = async (data: LoginInput) => {
+    setServerError(null)
+    const result = await login(data)
+    if (!result.success && result.error) {
+      setServerError(result.error)
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4" noValidate>
+        {serverError && (
+          <div className="p-3 text-sm text-red-500 bg-red-50 rounded-md">
+            {serverError}
+          </div>
+        )}
+
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>メールアドレス</FormLabel>
+              <FormControl>
+                <Input type="email" placeholder="example@example.com" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="password"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>パスワード</FormLabel>
+              <FormControl>
+                <Input type="password" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <Button type="submit" className="w-full">
+          ログイン
+        </Button>
+
+        <p className="text-center text-sm text-muted-foreground">
+          アカウントをお持ちでないですか？{' '}
+          <Link href="/signup" className="text-primary hover:underline">
+            新規登録
+          </Link>
+        </p>
+      </form>
+    </Form>
+  )
+}

--- a/components/auth/SignupForm.tsx
+++ b/components/auth/SignupForm.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import Link from 'next/link'
+import { signupSchema, type SignupInput } from '@/lib/validations/auth'
+import { signup } from '@/actions/auth'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+
+export function SignupForm() {
+  const [serverError, setServerError] = useState<string | null>(null)
+
+  const form = useForm<SignupInput>({
+    resolver: zodResolver(signupSchema),
+    defaultValues: {
+      email: '',
+      password: '',
+      confirmPassword: '',
+    },
+  })
+
+  const onSubmit = async (data: SignupInput) => {
+    setServerError(null)
+    const result = await signup(data)
+    if (!result.success && result.error) {
+      setServerError(result.error)
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4" noValidate>
+        {serverError && (
+          <div className="p-3 text-sm text-red-500 bg-red-50 rounded-md">
+            {serverError}
+          </div>
+        )}
+
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>メールアドレス</FormLabel>
+              <FormControl>
+                <Input type="email" placeholder="example@example.com" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="password"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>パスワード</FormLabel>
+              <FormControl>
+                <Input type="password" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="confirmPassword"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>パスワード（確認）</FormLabel>
+              <FormControl>
+                <Input type="password" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <Button type="submit" className="w-full">
+          新規登録
+        </Button>
+
+        <p className="text-center text-sm text-muted-foreground">
+          すでにアカウントをお持ちですか？{' '}
+          <Link href="/login" className="text-primary hover:underline">
+            ログイン
+          </Link>
+        </p>
+      </form>
+    </Form>
+  )
+}

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -12,6 +12,9 @@ const config: Config = {
   testEnvironment: "jsdom",
   // Add more setup options before each test is run
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -52,8 +52,8 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       return token
     },
     session({ session, token }) {
-      if (session.user) {
-        session.user.id = token.id as string
+      if (session.user && token.id) {
+        session.user.id = token.id
       }
       return session
     },

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,61 @@
+import NextAuth from 'next-auth'
+import Credentials from 'next-auth/providers/credentials'
+import bcrypt from 'bcryptjs'
+import { prisma } from '@/lib/prisma'
+import { loginSchema } from '@/lib/validations/auth'
+
+export const { handlers, signIn, signOut, auth } = NextAuth({
+  session: { strategy: 'jwt' },
+  pages: {
+    signIn: '/login',
+  },
+  providers: [
+    Credentials({
+      credentials: {
+        email: { label: 'Email', type: 'email' },
+        password: { label: 'Password', type: 'password' },
+      },
+      async authorize(credentials) {
+        const parsed = loginSchema.safeParse(credentials)
+        if (!parsed.success) {
+          return null
+        }
+
+        const { email, password } = parsed.data
+
+        const user = await prisma.user.findUnique({
+          where: { email },
+        })
+
+        if (!user || !user.password) {
+          return null
+        }
+
+        const isValidPassword = await bcrypt.compare(password, user.password)
+        if (!isValidPassword) {
+          return null
+        }
+
+        return {
+          id: user.id,
+          email: user.email,
+          name: user.name,
+        }
+      },
+    }),
+  ],
+  callbacks: {
+    jwt({ token, user }) {
+      if (user) {
+        token.id = user.id
+      }
+      return token
+    },
+    session({ session, token }) {
+      if (session.user) {
+        session.user.id = token.id as string
+      }
+      return session
+    },
+  },
+})

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -5,6 +5,7 @@ import { prisma } from '@/lib/prisma'
 import { loginSchema } from '@/lib/validations/auth'
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
+  secret: process.env.AUTH_SECRET,
   session: { strategy: 'jwt' },
   pages: {
     signIn: '/login',

--- a/lib/validations/auth.ts
+++ b/lib/validations/auth.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod'
+
+export const signupSchema = z
+  .object({
+    email: z.email('有効なメールアドレスを入力してください'),
+    password: z
+      .string()
+      .min(8, 'パスワードは8文字以上で入力してください'),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: 'パスワードが一致しません',
+    path: ['confirmPassword'],
+  })
+
+export const loginSchema = z.object({
+  email: z.email('有効なメールアドレスを入力してください'),
+  password: z.string().min(1, 'パスワードを入力してください'),
+})
+
+export type SignupInput = z.infer<typeof signupSchema>
+export type LoginInput = z.infer<typeof loginSchema>

--- a/lib/validations/auth.ts
+++ b/lib/validations/auth.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 export const signupSchema = z
   .object({
-    email: z.email('有効なメールアドレスを入力してください'),
+    email: z.string().email('有効なメールアドレスを入力してください'),
     password: z
       .string()
       .min(8, 'パスワードは8文字以上で入力してください'),
@@ -14,7 +14,7 @@ export const signupSchema = z
   })
 
 export const loginSchema = z.object({
-  email: z.email('有効なメールアドレスを入力してください'),
+  email: z.string().email('有効なメールアドレスを入力してください'),
   password: z.string().min(1, 'パスワードを入力してください'),
 })
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+import { auth } from '@/lib/auth'
+
+const protectedRoutes = ['/todos']
+const authRoutes = ['/login', '/signup']
+
+export async function middleware(request: NextRequest) {
+  const session = await auth()
+  const { pathname } = request.nextUrl
+
+  // Check if the route is protected
+  const isProtectedRoute = protectedRoutes.some((route) =>
+    pathname.startsWith(route)
+  )
+
+  // Check if the route is an auth route
+  const isAuthRoute = authRoutes.some((route) => pathname.startsWith(route))
+
+  // Redirect unauthenticated users from protected routes to login
+  if (isProtectedRoute && !session) {
+    const loginUrl = new URL('/login', request.url)
+    return NextResponse.redirect(loginUrl)
+  }
+
+  // Redirect authenticated users from auth routes to todos
+  if (isAuthRoute && session) {
+    const todosUrl = new URL('/todos', request.url)
+    return NextResponse.redirect(todosUrl)
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/todos/:path*', '/login', '/signup'],
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,13 +1,12 @@
 import { NextResponse } from 'next/server'
-import type { NextRequest } from 'next/server'
 import { auth } from '@/lib/auth'
 
 const protectedRoutes = ['/todos']
 const authRoutes = ['/login', '/signup']
 
-export async function middleware(request: NextRequest) {
-  const session = await auth()
-  const { pathname } = request.nextUrl
+export default auth((req) => {
+  const { pathname } = req.nextUrl
+  const session = req.auth
 
   // Check if the route is protected
   const isProtectedRoute = protectedRoutes.some((route) =>
@@ -19,18 +18,18 @@ export async function middleware(request: NextRequest) {
 
   // Redirect unauthenticated users from protected routes to login
   if (isProtectedRoute && !session) {
-    const loginUrl = new URL('/login', request.url)
+    const loginUrl = new URL('/login', req.url)
     return NextResponse.redirect(loginUrl)
   }
 
   // Redirect authenticated users from auth routes to todos
   if (isAuthRoute && session) {
-    const todosUrl = new URL('/todos', request.url)
+    const todosUrl = new URL('/todos', req.url)
     return NextResponse.redirect(todosUrl)
   }
 
   return NextResponse.next()
-}
+})
 
 export const config = {
   matcher: ['/todos/:path*', '/login', '/signup'],

--- a/proxy.ts
+++ b/proxy.ts
@@ -5,7 +5,7 @@ import type { NextRequest } from 'next/server'
 const protectedRoutes = ['/todos']
 const authRoutes = ['/login', '/signup']
 
-export async function middleware(req: NextRequest) {
+export async function proxy(req: NextRequest) {
   const { pathname } = req.nextUrl
   const token = await getToken({ req, secret: process.env.AUTH_SECRET })
 

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,0 +1,9 @@
+import { DefaultSession } from 'next-auth'
+
+declare module 'next-auth' {
+  interface Session {
+    user: {
+      id: string
+    } & DefaultSession['user']
+  }
+}

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,9 +1,16 @@
 import { DefaultSession } from 'next-auth'
+import { JWT as DefaultJWT } from 'next-auth/jwt'
 
 declare module 'next-auth' {
   interface Session {
     user: {
       id: string
     } & DefaultSession['user']
+  }
+}
+
+declare module 'next-auth/jwt' {
+  interface JWT extends DefaultJWT {
+    id?: string
   }
 }


### PR DESCRIPTION
## Summary
- NextAuth v5によるCredentials認証の実装
- サインアップ・ログイン・ログアウト機能
- ルート保護ミドルウェア（/todos保護、認証済みユーザーのauth routeリダイレクト）
- Headerの認証状態表示（未認証: 新規登録/ログインリンク、認証済み: ログアウトボタン）
- ToDo一覧ページ（ダミー）

## Test Plan
- [x] `npm run test` - 54テスト全てパス
- [x] `npm run lint` - エラーなし
- [x] `npx tsc --noEmit` - 型エラーなし

## Codex Review
- [x] Codex MCPによるコードレビュー完了
- [x] 全ての指摘事項を修正済み
  - z.email() → z.string().email()
  - middleware auth callback pattern
  - signup signIn error handling
  - JWT type extension
  - SessionProvider React import

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)