### PR TITLE
feat: Todo新規作成機能の実装

### DIFF
--- a/__tests__/actions/todo.test.ts
+++ b/__tests__/actions/todo.test.ts
@@ -1,0 +1,235 @@
+import { createTodo, getTodos } from '@/actions/todo'
+
+// Mock modules
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    todo: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+    },
+  },
+}))
+
+jest.mock('@/lib/auth', () => ({
+  auth: jest.fn(),
+}))
+
+jest.mock('next/cache', () => ({
+  revalidatePath: jest.fn(),
+}))
+
+// Import mocks after jest.mock
+import { prisma } from '@/lib/prisma'
+import { auth } from '@/lib/auth'
+import { revalidatePath } from 'next/cache'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockPrisma = prisma as any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockAuth = auth as jest.MockedFunction<any>
+const mockRevalidatePath = revalidatePath as jest.MockedFunction<typeof revalidatePath>
+
+describe('createTodo action', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should create a new todo for authenticated user', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'test@example.com', name: null },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+    })
+    mockPrisma.todo.create.mockResolvedValue({
+      id: 'todo-1',
+      userId: 'user-1',
+      title: 'タスク1',
+      memo: null,
+      isCompleted: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    const result = await createTodo({ title: 'タスク1' })
+
+    expect(result.success).toBe(true)
+    expect(mockPrisma.todo.create).toHaveBeenCalledWith({
+      data: {
+        userId: 'user-1',
+        title: 'タスク1',
+        memo: undefined,
+      },
+    })
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/todos')
+  })
+
+  it('should create a todo with memo', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'test@example.com', name: null },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+    })
+    mockPrisma.todo.create.mockResolvedValue({
+      id: 'todo-1',
+      userId: 'user-1',
+      title: 'タスク1',
+      memo: 'メモ内容',
+      isCompleted: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    const result = await createTodo({ title: 'タスク1', memo: 'メモ内容' })
+
+    expect(result.success).toBe(true)
+    expect(mockPrisma.todo.create).toHaveBeenCalledWith({
+      data: {
+        userId: 'user-1',
+        title: 'タスク1',
+        memo: 'メモ内容',
+      },
+    })
+  })
+
+  it('should return error for unauthenticated user', async () => {
+    mockAuth.mockResolvedValue(null)
+
+    const result = await createTodo({ title: 'タスク1' })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('認証が必要です')
+    }
+    expect(mockPrisma.todo.create).not.toHaveBeenCalled()
+  })
+
+  it('should return error for session without user id', async () => {
+    mockAuth.mockResolvedValue({
+      user: { email: 'test@example.com', name: null },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+    })
+
+    const result = await createTodo({ title: 'タスク1' })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('認証が必要です')
+    }
+    expect(mockPrisma.todo.create).not.toHaveBeenCalled()
+  })
+
+  it('should return error for invalid input', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'test@example.com', name: null },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+    })
+
+    const result = await createTodo({ title: '' })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('タイトルを入力してください')
+    }
+    expect(mockPrisma.todo.create).not.toHaveBeenCalled()
+  })
+
+  it('should return error for whitespace-only title', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'test@example.com', name: null },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+    })
+
+    const result = await createTodo({ title: '   ' })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('タイトルは空白のみでは登録できません')
+    }
+    expect(mockPrisma.todo.create).not.toHaveBeenCalled()
+  })
+})
+
+describe('getTodos action', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should return todos for authenticated user', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'test@example.com', name: null },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+    })
+    const mockTodos = [
+      {
+        id: 'todo-1',
+        userId: 'user-1',
+        title: 'タスク1',
+        memo: null,
+        isCompleted: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: 'todo-2',
+        userId: 'user-1',
+        title: 'タスク2',
+        memo: 'メモ',
+        isCompleted: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]
+    mockPrisma.todo.findMany.mockResolvedValue(mockTodos)
+
+    const result = await getTodos()
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.todos).toEqual(mockTodos)
+    }
+    expect(mockPrisma.todo.findMany).toHaveBeenCalledWith({
+      where: { userId: 'user-1' },
+      orderBy: { createdAt: 'desc' },
+    })
+  })
+
+  it('should return empty array when user has no todos', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'test@example.com', name: null },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+    })
+    mockPrisma.todo.findMany.mockResolvedValue([])
+
+    const result = await getTodos()
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.todos).toEqual([])
+    }
+  })
+
+  it('should return error for unauthenticated user', async () => {
+    mockAuth.mockResolvedValue(null)
+
+    const result = await getTodos()
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('認証が必要です')
+    }
+    expect(mockPrisma.todo.findMany).not.toHaveBeenCalled()
+  })
+
+  it('should return error for session without user id', async () => {
+    mockAuth.mockResolvedValue({
+      user: { email: 'test@example.com', name: null },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+    })
+
+    const result = await getTodos()
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('認証が必要です')
+    }
+    expect(mockPrisma.todo.findMany).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/app/todos/page.test.tsx
+++ b/__tests__/app/todos/page.test.tsx
@@ -12,23 +12,82 @@ jest.mock('@/lib/auth', () => ({
   }),
 }))
 
+// Mock getTodos action
+const mockGetTodos = jest.fn()
+jest.mock('@/actions/todo', () => ({
+  getTodos: () => mockGetTodos(),
+  createTodo: jest.fn(),
+}))
+
 describe('TodosPage', () => {
+  beforeEach(() => {
+    mockGetTodos.mockReset()
+  })
+
   it('should render the todos page with title', async () => {
+    mockGetTodos.mockResolvedValue({ success: true, todos: [] })
     render(await TodosPage())
 
     expect(screen.getByRole('heading', { name: 'ToDo一覧' })).toBeInTheDocument()
   })
 
   it('should have proper page structure', async () => {
+    mockGetTodos.mockResolvedValue({ success: true, todos: [] })
     render(await TodosPage())
 
     const main = screen.getByRole('main')
     expect(main).toBeInTheDocument()
   })
 
-  it('should display placeholder message', async () => {
+  it('should display empty message when no todos', async () => {
+    mockGetTodos.mockResolvedValue({ success: true, todos: [] })
     render(await TodosPage())
 
     expect(screen.getByText(/ToDoはまだありません/)).toBeInTheDocument()
+  })
+
+  it('should display add button', async () => {
+    mockGetTodos.mockResolvedValue({ success: true, todos: [] })
+    render(await TodosPage())
+
+    expect(screen.getByRole('button', { name: /タスクを追加/i })).toBeInTheDocument()
+  })
+
+  it('should display todos when available', async () => {
+    mockGetTodos.mockResolvedValue({
+      success: true,
+      todos: [
+        {
+          id: 'todo-1',
+          userId: 'user-1',
+          title: 'タスク1',
+          memo: null,
+          isCompleted: false,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 'todo-2',
+          userId: 'user-1',
+          title: 'タスク2',
+          memo: 'メモ',
+          isCompleted: true,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+    })
+    render(await TodosPage())
+
+    expect(screen.getByText('タスク1')).toBeInTheDocument()
+    expect(screen.getByText('タスク2')).toBeInTheDocument()
+    expect(screen.getByText('メモ')).toBeInTheDocument()
+  })
+
+  it('should display error message when getTodos fails', async () => {
+    mockGetTodos.mockResolvedValue({ success: false, error: 'エラーが発生しました' })
+    render(await TodosPage())
+
+    expect(screen.getByText('エラーが発生しました')).toBeInTheDocument()
   })
 })

--- a/__tests__/components/todo/TodoCreateButton.test.tsx
+++ b/__tests__/components/todo/TodoCreateButton.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { TodoCreateButton } from '@/components/todo/TodoCreateButton'
+
+// Mock the createTodo action
+const mockCreateTodo = jest.fn()
+jest.mock('@/actions/todo', () => ({
+  createTodo: (...args: unknown[]) => mockCreateTodo(...args),
+}))
+
+describe('TodoCreateButton', () => {
+  beforeEach(() => {
+    mockCreateTodo.mockReset()
+  })
+
+  it('should render the add button', () => {
+    render(<TodoCreateButton />)
+
+    expect(screen.getByRole('button', { name: /タスクを追加/i })).toBeInTheDocument()
+  })
+
+  it('should open dialog when button is clicked', async () => {
+    render(<TodoCreateButton />)
+
+    const addButton = screen.getByRole('button', { name: /タスクを追加/i })
+    fireEvent.click(addButton)
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+      expect(screen.getByText('新しいタスク')).toBeInTheDocument()
+    })
+  })
+
+  it('should show form fields in dialog', async () => {
+    render(<TodoCreateButton />)
+
+    const addButton = screen.getByRole('button', { name: /タスクを追加/i })
+    fireEvent.click(addButton)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('タイトル')).toBeInTheDocument()
+      expect(screen.getByLabelText('メモ（任意）')).toBeInTheDocument()
+    })
+  })
+
+  it('should close dialog after successful submission', async () => {
+    mockCreateTodo.mockResolvedValue({ success: true, todo: { id: 'todo-1' } })
+    render(<TodoCreateButton />)
+
+    // Open dialog
+    const addButton = screen.getByRole('button', { name: /タスクを追加/i })
+    fireEvent.click(addButton)
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+
+    // Fill form
+    const titleInput = screen.getByLabelText('タイトル')
+    fireEvent.change(titleInput, { target: { value: 'タスク1' } })
+
+    // Submit
+    const submitButton = screen.getByRole('button', { name: '追加' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/__tests__/components/todo/TodoForm.test.tsx
+++ b/__tests__/components/todo/TodoForm.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { TodoForm } from '@/components/todo/TodoForm'
+
+// Mock the createTodo action
+const mockCreateTodo = jest.fn()
+jest.mock('@/actions/todo', () => ({
+  createTodo: (...args: unknown[]) => mockCreateTodo(...args),
+}))
+
+describe('TodoForm', () => {
+  const mockOnSuccess = jest.fn()
+
+  beforeEach(() => {
+    mockCreateTodo.mockReset()
+    mockOnSuccess.mockReset()
+  })
+
+  it('should render all form fields', () => {
+    render(<TodoForm onSuccess={mockOnSuccess} />)
+
+    expect(screen.getByLabelText('タイトル')).toBeInTheDocument()
+    expect(screen.getByLabelText('メモ（任意）')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '追加' })).toBeInTheDocument()
+  })
+
+  it('should show validation error for empty title', async () => {
+    render(<TodoForm onSuccess={mockOnSuccess} />)
+
+    const submitButton = screen.getByRole('button', { name: '追加' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('タイトルを入力してください')).toBeInTheDocument()
+    })
+  })
+
+  it('should show validation error for whitespace-only title', async () => {
+    render(<TodoForm onSuccess={mockOnSuccess} />)
+
+    const titleInput = screen.getByLabelText('タイトル')
+    fireEvent.change(titleInput, { target: { value: '   ' } })
+
+    const submitButton = screen.getByRole('button', { name: '追加' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('タイトルは空白のみでは登録できません')).toBeInTheDocument()
+    })
+  })
+
+  it('should call createTodo action with form data on valid submission', async () => {
+    mockCreateTodo.mockResolvedValue({ success: true, todo: { id: 'todo-1' } })
+    render(<TodoForm onSuccess={mockOnSuccess} />)
+
+    const titleInput = screen.getByLabelText('タイトル')
+    fireEvent.change(titleInput, { target: { value: 'タスク1' } })
+
+    const submitButton = screen.getByRole('button', { name: '追加' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockCreateTodo).toHaveBeenCalledWith({
+        title: 'タスク1',
+        memo: undefined,
+      })
+    })
+  })
+
+  it('should call createTodo with memo when provided', async () => {
+    mockCreateTodo.mockResolvedValue({ success: true, todo: { id: 'todo-1' } })
+    render(<TodoForm onSuccess={mockOnSuccess} />)
+
+    const titleInput = screen.getByLabelText('タイトル')
+    fireEvent.change(titleInput, { target: { value: 'タスク1' } })
+
+    const memoInput = screen.getByLabelText('メモ（任意）')
+    fireEvent.change(memoInput, { target: { value: 'メモ内容' } })
+
+    const submitButton = screen.getByRole('button', { name: '追加' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockCreateTodo).toHaveBeenCalledWith({
+        title: 'タスク1',
+        memo: 'メモ内容',
+      })
+    })
+  })
+
+  it('should call onSuccess callback after successful submission', async () => {
+    mockCreateTodo.mockResolvedValue({ success: true, todo: { id: 'todo-1' } })
+    render(<TodoForm onSuccess={mockOnSuccess} />)
+
+    const titleInput = screen.getByLabelText('タイトル')
+    fireEvent.change(titleInput, { target: { value: 'タスク1' } })
+
+    const submitButton = screen.getByRole('button', { name: '追加' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockOnSuccess).toHaveBeenCalled()
+    })
+  })
+
+  it('should reset form after successful submission', async () => {
+    mockCreateTodo.mockResolvedValue({ success: true, todo: { id: 'todo-1' } })
+    render(<TodoForm onSuccess={mockOnSuccess} />)
+
+    const titleInput = screen.getByLabelText('タイトル')
+    fireEvent.change(titleInput, { target: { value: 'タスク1' } })
+
+    const submitButton = screen.getByRole('button', { name: '追加' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(titleInput).toHaveValue('')
+    })
+  })
+
+  it('should display server error message', async () => {
+    mockCreateTodo.mockResolvedValue({ success: false, error: 'エラーが発生しました' })
+    render(<TodoForm onSuccess={mockOnSuccess} />)
+
+    const titleInput = screen.getByLabelText('タイトル')
+    fireEvent.change(titleInput, { target: { value: 'タスク1' } })
+
+    const submitButton = screen.getByRole('button', { name: '追加' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('エラーが発生しました')).toBeInTheDocument()
+    })
+  })
+
+  it('should not call onSuccess when submission fails', async () => {
+    mockCreateTodo.mockResolvedValue({ success: false, error: 'エラーが発生しました' })
+    render(<TodoForm onSuccess={mockOnSuccess} />)
+
+    const titleInput = screen.getByLabelText('タイトル')
+    fireEvent.change(titleInput, { target: { value: 'タスク1' } })
+
+    const submitButton = screen.getByRole('button', { name: '追加' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('エラーが発生しました')).toBeInTheDocument()
+    })
+    expect(mockOnSuccess).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/components/todo/TodoItem.test.tsx
+++ b/__tests__/components/todo/TodoItem.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react'
+import { TodoItem } from '@/components/todo/TodoItem'
+
+describe('TodoItem', () => {
+  const baseTodo = {
+    id: 'todo-1',
+    title: 'タスク1',
+    isCompleted: false,
+    memo: null,
+  }
+
+  it('should render todo title', () => {
+    render(<TodoItem {...baseTodo} />)
+
+    expect(screen.getByText('タスク1')).toBeInTheDocument()
+  })
+
+  it('should render incomplete todo without strikethrough', () => {
+    render(<TodoItem {...baseTodo} isCompleted={false} />)
+
+    const title = screen.getByText('タスク1')
+    expect(title).not.toHaveClass('line-through')
+  })
+
+  it('should render completed todo with strikethrough', () => {
+    render(<TodoItem {...baseTodo} isCompleted={true} />)
+
+    const title = screen.getByText('タスク1')
+    expect(title).toHaveClass('line-through')
+  })
+
+  it('should show 未完了 status for incomplete todo', () => {
+    render(<TodoItem {...baseTodo} isCompleted={false} />)
+
+    expect(screen.getByText('未完了')).toBeInTheDocument()
+  })
+
+  it('should show 完了 status for completed todo', () => {
+    render(<TodoItem {...baseTodo} isCompleted={true} />)
+
+    expect(screen.getByText('完了')).toBeInTheDocument()
+  })
+
+  it('should render memo when provided', () => {
+    render(<TodoItem {...baseTodo} memo="メモ内容" />)
+
+    expect(screen.getByText('メモ内容')).toBeInTheDocument()
+  })
+
+  it('should not render memo section when memo is null', () => {
+    render(<TodoItem {...baseTodo} memo={null} />)
+
+    expect(screen.queryByText('メモ内容')).not.toBeInTheDocument()
+  })
+})

--- a/__tests__/components/todo/TodoList.test.tsx
+++ b/__tests__/components/todo/TodoList.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react'
+import { TodoList } from '@/components/todo/TodoList'
+
+describe('TodoList', () => {
+  const mockTodos = [
+    {
+      id: 'todo-1',
+      userId: 'user-1',
+      title: 'タスク1',
+      memo: null,
+      isCompleted: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      id: 'todo-2',
+      userId: 'user-1',
+      title: 'タスク2',
+      memo: 'メモ内容',
+      isCompleted: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  ]
+
+  it('should render empty state when no todos', () => {
+    render(<TodoList todos={[]} />)
+
+    expect(screen.getByText('ToDoはまだありません')).toBeInTheDocument()
+  })
+
+  it('should render list of todos', () => {
+    render(<TodoList todos={mockTodos} />)
+
+    expect(screen.getByText('タスク1')).toBeInTheDocument()
+    expect(screen.getByText('タスク2')).toBeInTheDocument()
+  })
+
+  it('should render memo for todo with memo', () => {
+    render(<TodoList todos={mockTodos} />)
+
+    expect(screen.getByText('メモ内容')).toBeInTheDocument()
+  })
+
+  it('should show correct completion status', () => {
+    render(<TodoList todos={mockTodos} />)
+
+    expect(screen.getByText('未完了')).toBeInTheDocument()
+    expect(screen.getByText('完了')).toBeInTheDocument()
+  })
+})

--- a/__tests__/lib/validations/todo.test.ts
+++ b/__tests__/lib/validations/todo.test.ts
@@ -1,0 +1,101 @@
+import { createTodoSchema, type CreateTodoInput } from '@/lib/validations/todo'
+
+describe('createTodoSchema', () => {
+  it('should validate correct todo data', () => {
+    const validData = {
+      title: 'タスク1',
+    }
+    const result = createTodoSchema.safeParse(validData)
+    expect(result.success).toBe(true)
+  })
+
+  it('should validate todo data with memo', () => {
+    const validData = {
+      title: 'タスク1',
+      memo: 'メモ内容',
+    }
+    const result = createTodoSchema.safeParse(validData)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.memo).toBe('メモ内容')
+    }
+  })
+
+  it('should transform empty memo to undefined', () => {
+    const validData = {
+      title: 'タスク1',
+      memo: '',
+    }
+    const result = createTodoSchema.safeParse(validData)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.memo).toBeUndefined()
+    }
+  })
+
+  it('should reject empty title', () => {
+    const invalidData = {
+      title: '',
+    }
+    const result = createTodoSchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('title')
+      expect(result.error.issues[0].message).toBe('タイトルを入力してください')
+    }
+  })
+
+  it('should reject whitespace-only title', () => {
+    const invalidData = {
+      title: '   ',
+    }
+    const result = createTodoSchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('title')
+      expect(result.error.issues[0].message).toBe('タイトルは空白のみでは登録できません')
+    }
+  })
+
+  it('should reject title longer than 100 characters', () => {
+    const invalidData = {
+      title: 'a'.repeat(101),
+    }
+    const result = createTodoSchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('title')
+      expect(result.error.issues[0].message).toBe('タイトルは100文字以内で入力してください')
+    }
+  })
+
+  it('should accept title with exactly 100 characters', () => {
+    const validData = {
+      title: 'a'.repeat(100),
+    }
+    const result = createTodoSchema.safeParse(validData)
+    expect(result.success).toBe(true)
+  })
+
+  it('should reject memo longer than 1000 characters', () => {
+    const invalidData = {
+      title: 'タスク1',
+      memo: 'a'.repeat(1001),
+    }
+    const result = createTodoSchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('memo')
+      expect(result.error.issues[0].message).toBe('メモは1000文字以内で入力してください')
+    }
+  })
+
+  it('should accept memo with exactly 1000 characters', () => {
+    const validData = {
+      title: 'タスク1',
+      memo: 'a'.repeat(1000),
+    }
+    const result = createTodoSchema.safeParse(validData)
+    expect(result.success).toBe(true)
+  })
+})

--- a/__tests__/lib/validations/todo.test.ts
+++ b/__tests__/lib/validations/todo.test.ts
@@ -1,4 +1,4 @@
-import { createTodoSchema, type CreateTodoInput } from '@/lib/validations/todo'
+import { createTodoSchema } from '@/lib/validations/todo'
 
 describe('createTodoSchema', () => {
   it('should validate correct todo data', () => {

--- a/actions/todo.ts
+++ b/actions/todo.ts
@@ -1,0 +1,57 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { prisma } from '@/lib/prisma'
+import { auth } from '@/lib/auth'
+import { createTodoSchema, type CreateTodoInput } from '@/lib/validations/todo'
+import type { TodoModel as Todo } from '@/src/generated/prisma/models'
+
+export type CreateTodoResult =
+  | { success: true; todo: Todo }
+  | { success: false; error: string }
+
+export type GetTodosResult =
+  | { success: true; todos: Todo[] }
+  | { success: false; error: string }
+
+export async function createTodo(data: CreateTodoInput): Promise<CreateTodoResult> {
+  const session = await auth()
+
+  if (!session?.user?.id) {
+    return { success: false, error: '認証が必要です' }
+  }
+
+  const parsed = createTodoSchema.safeParse(data)
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0].message }
+  }
+
+  const { title, memo } = parsed.data
+
+  const todo = await prisma.todo.create({
+    data: {
+      userId: session.user.id,
+      title,
+      memo,
+    },
+  })
+
+  revalidatePath('/todos')
+
+  return { success: true, todo }
+}
+
+export async function getTodos(): Promise<GetTodosResult> {
+  const session = await auth()
+
+  if (!session?.user?.id) {
+    return { success: false, error: '認証が必要です' }
+  }
+
+  const todos = await prisma.todo.findMany({
+    where: { userId: session.user.id },
+    orderBy: { createdAt: 'desc' },
+  })
+
+  return { success: true, todos }
+}

--- a/actions/todo.ts
+++ b/actions/todo.ts
@@ -28,17 +28,22 @@ export async function createTodo(data: CreateTodoInput): Promise<CreateTodoResul
 
   const { title, memo } = parsed.data
 
-  const todo = await prisma.todo.create({
-    data: {
-      userId: session.user.id,
-      title,
-      memo,
-    },
-  })
+  try {
+    const todo = await prisma.todo.create({
+      data: {
+        userId: session.user.id,
+        title,
+        memo,
+      },
+    })
 
-  revalidatePath('/todos')
+    revalidatePath('/todos')
 
-  return { success: true, todo }
+    return { success: true, todo }
+  } catch (error) {
+    console.error('Failed to create todo:', error)
+    return { success: false, error: 'タスクの作成に失敗しました' }
+  }
 }
 
 export async function getTodos(): Promise<GetTodosResult> {
@@ -48,10 +53,15 @@ export async function getTodos(): Promise<GetTodosResult> {
     return { success: false, error: '認証が必要です' }
   }
 
-  const todos = await prisma.todo.findMany({
-    where: { userId: session.user.id },
-    orderBy: { createdAt: 'desc' },
-  })
+  try {
+    const todos = await prisma.todo.findMany({
+      where: { userId: session.user.id },
+      orderBy: { createdAt: 'desc' },
+    })
 
-  return { success: true, todos }
+    return { success: true, todos }
+  } catch (error) {
+    console.error('Failed to fetch todos:', error)
+    return { success: false, error: 'タスクの取得に失敗しました' }
+  }
 }

--- a/app/todos/page.tsx
+++ b/app/todos/page.tsx
@@ -1,17 +1,31 @@
+import { redirect } from 'next/navigation'
 import { auth } from '@/lib/auth'
+import { getTodos } from '@/actions/todo'
+import { TodoCreateButton } from '@/components/todo/TodoCreateButton'
+import { TodoList } from '@/components/todo/TodoList'
 
 export default async function TodosPage() {
   const session = await auth()
 
+  if (!session?.user?.id) {
+    redirect('/login')
+  }
+
+  const result = await getTodos()
+
   return (
     <main className="container mx-auto px-4 py-8">
-      <h1 className="text-2xl font-bold mb-6">ToDo一覧</h1>
-      <div className="text-center py-12 text-muted-foreground">
-        <p>ToDoはまだありません</p>
-        <p className="text-sm mt-2">
-          ようこそ、{session?.user?.email}さん
-        </p>
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold">ToDo一覧</h1>
+        <TodoCreateButton />
       </div>
+      {result.success ? (
+        <TodoList todos={result.todos} />
+      ) : (
+        <div className="text-center py-12 text-red-500">
+          <p>{result.error}</p>
+        </div>
+      )}
     </main>
   )
 }

--- a/components/todo/TodoCreateButton.tsx
+++ b/components/todo/TodoCreateButton.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { TodoForm } from './TodoForm'
+
+export function TodoCreateButton() {
+  const [open, setOpen] = useState(false)
+
+  const handleSuccess = () => {
+    setOpen(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button>+ タスクを追加</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>新しいタスク</DialogTitle>
+          <DialogDescription>
+            タイトルとメモを入力して新しいタスクを追加します
+          </DialogDescription>
+        </DialogHeader>
+        <TodoForm onSuccess={handleSuccess} />
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/todo/TodoForm.tsx
+++ b/components/todo/TodoForm.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { createTodoSchema, type CreateTodoInput } from '@/lib/validations/todo'
+import { createTodo } from '@/actions/todo'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+
+interface TodoFormProps {
+  onSuccess: () => void
+}
+
+export function TodoForm({ onSuccess }: TodoFormProps) {
+  const [serverError, setServerError] = useState<string | null>(null)
+
+  const form = useForm<CreateTodoInput>({
+    resolver: zodResolver(createTodoSchema),
+    defaultValues: {
+      title: '',
+      memo: '',
+    },
+  })
+
+  const onSubmit = async (data: CreateTodoInput) => {
+    setServerError(null)
+    const result = await createTodo(data)
+    if (result.success) {
+      form.reset()
+      onSuccess()
+    } else {
+      setServerError(result.error)
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4" noValidate>
+        {serverError && (
+          <div className="p-3 text-sm text-red-500 bg-red-50 rounded-md">
+            {serverError}
+          </div>
+        )}
+
+        <FormField
+          control={form.control}
+          name="title"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>タイトル</FormLabel>
+              <FormControl>
+                <Input placeholder="タスクを入力" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="memo"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>メモ（任意）</FormLabel>
+              <FormControl>
+                <Textarea placeholder="メモを入力（任意）" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <Button type="submit" className="w-full">
+          追加
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/components/todo/TodoItem.tsx
+++ b/components/todo/TodoItem.tsx
@@ -1,0 +1,38 @@
+import { cn } from '@/lib/utils'
+
+interface TodoItemProps {
+  id: string
+  title: string
+  isCompleted: boolean
+  memo: string | null
+}
+
+export function TodoItem({ title, isCompleted, memo }: TodoItemProps) {
+  return (
+    <div className="border rounded-lg p-4 bg-card">
+      <div className="flex items-center justify-between">
+        <h3
+          className={cn(
+            'font-medium',
+            isCompleted && 'line-through text-muted-foreground'
+          )}
+        >
+          {title}
+        </h3>
+        <span
+          className={cn(
+            'text-xs px-2 py-1 rounded-full',
+            isCompleted
+              ? 'bg-green-100 text-green-700'
+              : 'bg-yellow-100 text-yellow-700'
+          )}
+        >
+          {isCompleted ? '完了' : '未完了'}
+        </span>
+      </div>
+      {memo && (
+        <p className="text-sm text-muted-foreground mt-2">{memo}</p>
+      )}
+    </div>
+  )
+}

--- a/components/todo/TodoList.tsx
+++ b/components/todo/TodoList.tsx
@@ -1,0 +1,39 @@
+import { TodoItem } from './TodoItem'
+
+interface Todo {
+  id: string
+  userId: string
+  title: string
+  memo: string | null
+  isCompleted: boolean
+  createdAt: Date
+  updatedAt: Date
+}
+
+interface TodoListProps {
+  todos: Todo[]
+}
+
+export function TodoList({ todos }: TodoListProps) {
+  if (todos.length === 0) {
+    return (
+      <div className="text-center py-12 text-muted-foreground">
+        <p>ToDoはまだありません</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      {todos.map((todo) => (
+        <TodoItem
+          key={todo.id}
+          id={todo.id}
+          title={todo.title}
+          isCompleted={todo.isCompleted}
+          memo={todo.memo}
+        />
+      ))}
+    </div>
+  )
+}

--- a/components/todo/TodoList.tsx
+++ b/components/todo/TodoList.tsx
@@ -1,14 +1,5 @@
+import type { TodoModel as Todo } from '@/src/generated/prisma/models'
 import { TodoItem } from './TodoItem'
-
-interface Todo {
-  id: string
-  userId: string
-  title: string
-  memo: string | null
-  isCompleted: boolean
-  createdAt: Date
-  updatedAt: Date
-}
 
 interface TodoListProps {
   todos: Todo[]

--- a/components/todo/TodoList.tsx
+++ b/components/todo/TodoList.tsx
@@ -8,14 +8,14 @@ interface TodoListProps {
 export function TodoList({ todos }: TodoListProps) {
   if (todos.length === 0) {
     return (
-      <div className="text-center py-12 text-muted-foreground">
+      <div className="text-center py-12 text-muted-foreground max-w-2xl mx-auto">
         <p>ToDoはまだありません</p>
       </div>
     )
   }
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-3 max-w-2xl mx-auto">
       {todos.map((todo) => (
         <TodoItem
           key={todo.id}

--- a/lib/validations/todo.ts
+++ b/lib/validations/todo.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod'
+
+export const createTodoSchema = z.object({
+  title: z
+    .string()
+    .min(1, 'タイトルを入力してください')
+    .max(100, 'タイトルは100文字以内で入力してください')
+    .refine((val) => val.trim().length > 0, {
+      message: 'タイトルは空白のみでは登録できません',
+    }),
+  memo: z
+    .string()
+    .max(1000, 'メモは1000文字以内で入力してください')
+    .optional()
+    .transform((val) => val || undefined),
+})
+
+export type CreateTodoInput = z.infer<typeof createTodoSchema>

--- a/lib/validations/todo.ts
+++ b/lib/validations/todo.ts
@@ -5,14 +5,15 @@ export const createTodoSchema = z.object({
     .string()
     .min(1, 'タイトルを入力してください')
     .max(100, 'タイトルは100文字以内で入力してください')
-    .refine((val) => val.trim().length > 0, {
+    .transform((val) => val.trim())
+    .refine((val) => val.length > 0, {
       message: 'タイトルは空白のみでは登録できません',
     }),
   memo: z
     .string()
     .max(1000, 'メモは1000文字以内で入力してください')
     .optional()
-    .transform((val) => val || undefined),
+    .transform((val) => (val?.trim() || undefined)),
 })
 
 export type CreateTodoInput = z.input<typeof createTodoSchema>

--- a/lib/validations/todo.ts
+++ b/lib/validations/todo.ts
@@ -15,4 +15,5 @@ export const createTodoSchema = z.object({
     .transform((val) => val || undefined),
 })
 
-export type CreateTodoInput = z.infer<typeof createTodoSchema>
+export type CreateTodoInput = z.input<typeof createTodoSchema>
+export type CreateTodoOutput = z.output<typeof createTodoSchema>


### PR DESCRIPTION
## Summary
- 認証済みユーザーがToDoを作成・一覧表示できる機能を実装
- Zodバリデーションスキーマ（タイトル必須、100文字以内、メモは1000文字以内）
- Server Actions（createTodo, getTodos）with 認可チェック・エラーハンドリング
- TodoItem、TodoList、TodoForm、TodoCreateButtonコンポーネント
- TodosPageへの統合

## Codex Review
- [x] Codex MCPによるコードレビュー完了
- [x] 全ての指摘事項を修正済み
  - DBエラーハンドリングを追加
  - タイトル・メモのtrim正規化
  - 共有型の使用

## Test Plan
- [x] テストが全てパスする（100テスト）
- [x] 新規テストを追加した
- [x] lint/型エラーがない

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)