### PR TITLE
fix: 本番環境でログイン後に/todosに遷移しない問題を修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -352,8 +352,8 @@ model Todo {
 ```bash
 DATABASE_URL="postgresql://..."    # Prisma接続用
 DIRECT_URL="postgresql://..."      # マイグレーション用
-NEXTAUTH_SECRET="..."              # NextAuth用
-NEXTAUTH_URL="http://localhost:3000"
+AUTH_SECRET="..."                  # Auth.js用
+AUTH_URL="http://localhost:3000"   # Auth.js用（本番はhttpsのURL）
 ```
 
 ## PRマージ前チェックリスト

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,3 +1,5 @@
 import { handlers } from '@/lib/auth'
 
+export const runtime = 'nodejs'
+
 export const { GET, POST } = handlers

--- a/app/todos/page.tsx
+++ b/app/todos/page.tsx
@@ -4,6 +4,8 @@ import { getTodos } from '@/actions/todo'
 import { TodoCreateButton } from '@/components/todo/TodoCreateButton'
 import { TodoList } from '@/components/todo/TodoList'
 
+export const dynamic = 'force-dynamic'
+
 export default async function TodosPage() {
   const session = await auth()
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -5,7 +5,6 @@ import { prisma } from '@/lib/prisma'
 import { loginSchema } from '@/lib/validations/auth'
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
-  secret: process.env.AUTH_SECRET,
   session: { strategy: 'jwt' },
   pages: {
     signIn: '/login',

--- a/proxy.ts
+++ b/proxy.ts
@@ -7,7 +7,7 @@ const authRoutes = ['/login', '/signup']
 
 export async function proxy(req: NextRequest) {
   const { pathname } = req.nextUrl
-  const token = await getToken({ req, secret: process.env.AUTH_SECRET })
+  const token = await getToken({ req })
 
   // Check if the route is protected
   const isProtectedRoute = protectedRoutes.some((route) =>

--- a/proxy.ts
+++ b/proxy.ts
@@ -7,7 +7,11 @@ const authRoutes = ['/login', '/signup']
 
 export async function proxy(req: NextRequest) {
   const { pathname } = req.nextUrl
-  const token = await getToken({ req })
+  const secret = process.env.AUTH_SECRET
+  if (!secret) {
+    throw new Error('AUTH_SECRET environment variable is not set')
+  }
+  const token = await getToken({ req, secret })
 
   // Check if the route is protected
   const isProtectedRoute = protectedRoutes.some((route) =>


### PR DESCRIPTION
## Summary
- Vercel本番環境でログイン後に/todosへ遷移せず、/loginにリダイレクトされる問題を修正
- 原因: Auth.jsのセッション取得が正しく動作していなかった

## Changes
- `app/api/auth/[...nextauth]/route.ts`: `runtime = 'nodejs'`を追加（Edge最適化を防止）
- `app/todos/page.tsx`: `dynamic = 'force-dynamic'`を追加（静的最適化を防止）
- `lib/auth.ts`: `secret`を削除しAuth.jsのデフォルト挙動に統一
- `proxy.ts`: `AUTH_SECRET`の必須チェックを追加
- `CLAUDE.md`: 環境変数を`AUTH_SECRET`/`AUTH_URL`に更新

## Codex Review
- [x] Codex MCPによるコードレビュー完了
- [x] 全ての指摘事項を修正済み

## Test Plan
- [x] テストが全てパスする（100 tests passed）
- [x] lint/型エラーがない
- [ ] 本番環境で動作確認

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)