### PR TITLE
feat: ToDoの編集・削除機能を実装

### DIFF
--- a/__tests__/actions/todo.test.ts
+++ b/__tests__/actions/todo.test.ts
@@ -1,4 +1,4 @@
-import { createTodo, getTodos } from '@/actions/todo'
+import { createTodo, getTodos, updateTodo, deleteTodo, toggleTodoComplete } from '@/actions/todo'
 
 // Mock modules
 jest.mock('@/lib/prisma', () => ({
@@ -6,6 +6,9 @@ jest.mock('@/lib/prisma', () => ({
     todo: {
       create: jest.fn(),
       findMany: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
     },
   },
 }))
@@ -231,5 +234,380 @@ describe('getTodos action', () => {
       expect(result.error).toBe('認証が必要です')
     }
     expect(mockPrisma.todo.findMany).not.toHaveBeenCalled()
+  })
+})
+
+describe('updateTodo action', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  const validUpdateData = {
+    id: 'todo-1',
+    title: '更新後のタスク',
+    memo: '更新後のメモ',
+    isCompleted: true,
+  }
+
+  it('should update todo for authenticated user', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'test@example.com', name: null },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+    })
+    mockPrisma.todo.findUnique.mockResolvedValue({
+      id: 'todo-1',
+      userId: 'user-1',
+      title: 'タスク1',
+      memo: null,
+      isCompleted: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    mockPrisma.todo.update.mockResolvedValue({
+      id: 'todo-1',
+      userId: 'user-1',
+      title: '更新後のタスク',
+      memo: '更新後のメモ',
+      isCompleted: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    const result = await updateTodo(validUpdateData)
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.todo.title).toBe('更新後のタスク')
+      expect(result.todo.memo).toBe('更新後のメモ')
+      expect(result.todo.isCompleted).toBe(true)
+    }
+    expect(mockPrisma.todo.update).toHaveBeenCalledWith({
+      where: { id: 'todo-1' },
+      data: {
+        title: '更新後のタスク',
+        memo: '更新後のメモ',
+        isCompleted: true,
+      },
+    })
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/todos')
+  })
+
+  it('should return error for unauthenticated user', async () => {
+    mockAuth.mockResolvedValue(null)
+
+    const result = await updateTodo(validUpdateData)
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('認証が必要です')
+    }
+    expect(mockPrisma.todo.findUnique).not.toHaveBeenCalled()
+  })
+
+  it('should return error for invalid input', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'test@example.com', name: null },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+    })
+
+    const result = await updateTodo({ ...validUpdateData, title: '' })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('タイトルを入力してください')
+    }
+    expect(mockPrisma.todo.findUnique).not.toHaveBeenCalled()
+  })
+
+  it('should return error for non-existent todo', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'test@example.com', name: null },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+    })
+    mockPrisma.todo.findUnique.mockResolvedValue(null)
+
+    const result = await updateTodo(validUpdateData)
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('タスクが見つかりません')
+    }
+    expect(mockPrisma.todo.update).not.toHaveBeenCalled()
+  })
+
+  it('should return error when updating other user todo', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'test@example.com', name: null },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+    })
+    mockPrisma.todo.findUnique.mockResolvedValue({
+      id: 'todo-1',
+      userId: 'user-2', // Different user
+      title: 'タスク1',
+      memo: null,
+      isCompleted: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    const result = await updateTodo(validUpdateData)
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('タスクが見つかりません') // Same error for security
+    }
+    expect(mockPrisma.todo.update).not.toHaveBeenCalled()
+  })
+})
+
+describe('deleteTodo action', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should delete todo for authenticated user', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'test@example.com', name: null },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+    })
+    mockPrisma.todo.findUnique.mockResolvedValue({
+      id: 'todo-1',
+      userId: 'user-1',
+      title: 'タスク1',
+      memo: null,
+      isCompleted: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    mockPrisma.todo.delete.mockResolvedValue({
+      id: 'todo-1',
+      userId: 'user-1',
+      title: 'タスク1',
+      memo: null,
+      isCompleted: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    const result = await deleteTodo('todo-1')
+
+    expect(result.success).toBe(true)
+    expect(mockPrisma.todo.delete).toHaveBeenCalledWith({
+      where: { id: 'todo-1' },
+    })
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/todos')
+  })
+
+  it('should return error for unauthenticated user', async () => {
+    mockAuth.mockResolvedValue(null)
+
+    const result = await deleteTodo('todo-1')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('認証が必要です')
+    }
+    expect(mockPrisma.todo.findUnique).not.toHaveBeenCalled()
+  })
+
+  it('should return error for non-existent todo', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'test@example.com', name: null },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+    })
+    mockPrisma.todo.findUnique.mockResolvedValue(null)
+
+    const result = await deleteTodo('todo-1')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('タスクが見つかりません')
+    }
+    expect(mockPrisma.todo.delete).not.toHaveBeenCalled()
+  })
+
+  it('should return error when deleting other user todo', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'test@example.com', name: null },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+    })
+    mockPrisma.todo.findUnique.mockResolvedValue({
+      id: 'todo-1',
+      userId: 'user-2', // Different user
+      title: 'タスク1',
+      memo: null,
+      isCompleted: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    const result = await deleteTodo('todo-1')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('タスクが見つかりません')
+    }
+    expect(mockPrisma.todo.delete).not.toHaveBeenCalled()
+  })
+
+  it('should return error for empty id', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'test@example.com', name: null },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+    })
+
+    const result = await deleteTodo('')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('IDが必要です')
+    }
+    expect(mockPrisma.todo.findUnique).not.toHaveBeenCalled()
+  })
+})
+
+describe('toggleTodoComplete action', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should toggle incomplete todo to complete', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'test@example.com', name: null },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+    })
+    mockPrisma.todo.findUnique.mockResolvedValue({
+      id: 'todo-1',
+      userId: 'user-1',
+      title: 'タスク1',
+      memo: null,
+      isCompleted: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    mockPrisma.todo.update.mockResolvedValue({
+      id: 'todo-1',
+      userId: 'user-1',
+      title: 'タスク1',
+      memo: null,
+      isCompleted: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    const result = await toggleTodoComplete('todo-1')
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.todo.isCompleted).toBe(true)
+    }
+    expect(mockPrisma.todo.update).toHaveBeenCalledWith({
+      where: { id: 'todo-1' },
+      data: { isCompleted: true },
+    })
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/todos')
+  })
+
+  it('should toggle complete todo to incomplete', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'test@example.com', name: null },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+    })
+    mockPrisma.todo.findUnique.mockResolvedValue({
+      id: 'todo-1',
+      userId: 'user-1',
+      title: 'タスク1',
+      memo: null,
+      isCompleted: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    mockPrisma.todo.update.mockResolvedValue({
+      id: 'todo-1',
+      userId: 'user-1',
+      title: 'タスク1',
+      memo: null,
+      isCompleted: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    const result = await toggleTodoComplete('todo-1')
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.todo.isCompleted).toBe(false)
+    }
+    expect(mockPrisma.todo.update).toHaveBeenCalledWith({
+      where: { id: 'todo-1' },
+      data: { isCompleted: false },
+    })
+  })
+
+  it('should return error for unauthenticated user', async () => {
+    mockAuth.mockResolvedValue(null)
+
+    const result = await toggleTodoComplete('todo-1')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('認証が必要です')
+    }
+    expect(mockPrisma.todo.findUnique).not.toHaveBeenCalled()
+  })
+
+  it('should return error for non-existent todo', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'test@example.com', name: null },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+    })
+    mockPrisma.todo.findUnique.mockResolvedValue(null)
+
+    const result = await toggleTodoComplete('todo-1')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('タスクが見つかりません')
+    }
+    expect(mockPrisma.todo.update).not.toHaveBeenCalled()
+  })
+
+  it('should return error when toggling other user todo', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'test@example.com', name: null },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+    })
+    mockPrisma.todo.findUnique.mockResolvedValue({
+      id: 'todo-1',
+      userId: 'user-2',
+      title: 'タスク1',
+      memo: null,
+      isCompleted: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    const result = await toggleTodoComplete('todo-1')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('タスクが見つかりません')
+    }
+    expect(mockPrisma.todo.update).not.toHaveBeenCalled()
+  })
+
+  it('should return error for empty id', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'test@example.com', name: null },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+    })
+
+    const result = await toggleTodoComplete('')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('IDが必要です')
+    }
+    expect(mockPrisma.todo.findUnique).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/actions/todo.test.ts
+++ b/__tests__/actions/todo.test.ts
@@ -59,7 +59,7 @@ describe('createTodo action', () => {
       data: {
         userId: 'user-1',
         title: 'タスク1',
-        memo: undefined,
+        memo: null, // undefined from zod is converted to null for Prisma
       },
     })
     expect(mockRevalidatePath).toHaveBeenCalledWith('/todos')

--- a/__tests__/components/todo/TodoDeleteDialog.test.tsx
+++ b/__tests__/components/todo/TodoDeleteDialog.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { TodoDeleteDialog } from '@/components/todo/TodoDeleteDialog'
+
+// Mock the deleteTodo action
+const mockDeleteTodo = jest.fn()
+jest.mock('@/actions/todo', () => ({
+  deleteTodo: (...args: unknown[]) => mockDeleteTodo(...args),
+}))
+
+describe('TodoDeleteDialog', () => {
+  const defaultProps = {
+    open: true,
+    onOpenChange: jest.fn(),
+    todoId: 'todo-1',
+    todoTitle: 'タスク1',
+  }
+
+  beforeEach(() => {
+    mockDeleteTodo.mockReset()
+    defaultProps.onOpenChange.mockReset()
+  })
+
+  it('should render dialog when open', () => {
+    render(<TodoDeleteDialog {...defaultProps} />)
+
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument()
+    expect(screen.getByText('タスクを削除')).toBeInTheDocument()
+  })
+
+  it('should not render dialog when closed', () => {
+    render(<TodoDeleteDialog {...defaultProps} open={false} />)
+
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+  })
+
+  it('should display todo title in confirmation message', () => {
+    render(<TodoDeleteDialog {...defaultProps} />)
+
+    expect(screen.getByText(/「タスク1」を削除しますか/)).toBeInTheDocument()
+  })
+
+  it('should call deleteTodo with todo id on confirm', async () => {
+    mockDeleteTodo.mockResolvedValue({ success: true })
+    render(<TodoDeleteDialog {...defaultProps} />)
+
+    const deleteButton = screen.getByRole('button', { name: '削除' })
+    fireEvent.click(deleteButton)
+
+    await waitFor(() => {
+      expect(mockDeleteTodo).toHaveBeenCalledWith('todo-1')
+    })
+  })
+
+  it('should close dialog on successful delete', async () => {
+    mockDeleteTodo.mockResolvedValue({ success: true })
+    render(<TodoDeleteDialog {...defaultProps} />)
+
+    const deleteButton = screen.getByRole('button', { name: '削除' })
+    fireEvent.click(deleteButton)
+
+    await waitFor(() => {
+      expect(defaultProps.onOpenChange).toHaveBeenCalledWith(false)
+    })
+  })
+
+  it('should show error message on delete failure', async () => {
+    mockDeleteTodo.mockResolvedValue({ success: false, error: 'タスクが見つかりません' })
+    render(<TodoDeleteDialog {...defaultProps} />)
+
+    const deleteButton = screen.getByRole('button', { name: '削除' })
+    fireEvent.click(deleteButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('タスクが見つかりません')).toBeInTheDocument()
+    })
+    expect(defaultProps.onOpenChange).not.toHaveBeenCalledWith(false)
+  })
+
+  it('should disable delete button while deleting', async () => {
+    mockDeleteTodo.mockImplementation(() => new Promise(() => {})) // Never resolves
+    render(<TodoDeleteDialog {...defaultProps} />)
+
+    const deleteButton = screen.getByRole('button', { name: '削除' })
+    fireEvent.click(deleteButton)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '削除中...' })).toBeDisabled()
+    })
+  })
+
+  it('should close dialog when cancel button is clicked', () => {
+    render(<TodoDeleteDialog {...defaultProps} />)
+
+    const cancelButton = screen.getByRole('button', { name: 'キャンセル' })
+    fireEvent.click(cancelButton)
+
+    expect(defaultProps.onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/__tests__/components/todo/TodoEditDialog.test.tsx
+++ b/__tests__/components/todo/TodoEditDialog.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { TodoEditDialog } from '@/components/todo/TodoEditDialog'
+
+// Mock the updateTodo action
+const mockUpdateTodo = jest.fn()
+jest.mock('@/actions/todo', () => ({
+  updateTodo: (...args: unknown[]) => mockUpdateTodo(...args),
+}))
+
+describe('TodoEditDialog', () => {
+  const baseTodo = {
+    id: 'todo-1',
+    title: 'タスク1',
+    memo: 'メモ内容',
+    isCompleted: false,
+  }
+
+  const defaultProps = {
+    open: true,
+    onOpenChange: jest.fn(),
+    todo: baseTodo,
+  }
+
+  beforeEach(() => {
+    mockUpdateTodo.mockReset()
+    defaultProps.onOpenChange.mockReset()
+  })
+
+  it('should render dialog when open', () => {
+    render(<TodoEditDialog {...defaultProps} />)
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText('タスクを編集')).toBeInTheDocument()
+  })
+
+  it('should not render dialog when closed', () => {
+    render(<TodoEditDialog {...defaultProps} open={false} />)
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('should populate form with todo data', () => {
+    render(<TodoEditDialog {...defaultProps} />)
+
+    expect(screen.getByLabelText('タイトル')).toHaveValue('タスク1')
+    expect(screen.getByLabelText('メモ（任意）')).toHaveValue('メモ内容')
+  })
+
+  it('should show unchecked checkbox for incomplete todo', () => {
+    render(<TodoEditDialog {...defaultProps} />)
+
+    const checkbox = screen.getByRole('checkbox', { name: /完了/i })
+    expect(checkbox).not.toBeChecked()
+  })
+
+  it('should show checked checkbox for completed todo', () => {
+    render(<TodoEditDialog {...defaultProps} todo={{ ...baseTodo, isCompleted: true }} />)
+
+    const checkbox = screen.getByRole('checkbox', { name: /完了/i })
+    expect(checkbox).toBeChecked()
+  })
+
+  it('should call updateTodo with form data on submit', async () => {
+    mockUpdateTodo.mockResolvedValue({ success: true, todo: { ...baseTodo, title: '更新後' } })
+    render(<TodoEditDialog {...defaultProps} />)
+
+    // Update title
+    const titleInput = screen.getByLabelText('タイトル')
+    fireEvent.change(titleInput, { target: { value: '更新後' } })
+
+    // Submit
+    const submitButton = screen.getByRole('button', { name: '保存' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockUpdateTodo).toHaveBeenCalledWith({
+        id: 'todo-1',
+        title: '更新後',
+        memo: 'メモ内容',
+        isCompleted: false,
+      })
+    })
+  })
+
+  it('should close dialog on successful update', async () => {
+    mockUpdateTodo.mockResolvedValue({ success: true, todo: baseTodo })
+    render(<TodoEditDialog {...defaultProps} />)
+
+    const submitButton = screen.getByRole('button', { name: '保存' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(defaultProps.onOpenChange).toHaveBeenCalledWith(false)
+    })
+  })
+
+  it('should show validation error for empty title', async () => {
+    render(<TodoEditDialog {...defaultProps} />)
+
+    const titleInput = screen.getByLabelText('タイトル')
+    fireEvent.change(titleInput, { target: { value: '' } })
+
+    const submitButton = screen.getByRole('button', { name: '保存' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('タイトルを入力してください')).toBeInTheDocument()
+    })
+    expect(mockUpdateTodo).not.toHaveBeenCalled()
+  })
+
+  it('should show server error on update failure', async () => {
+    mockUpdateTodo.mockResolvedValue({ success: false, error: 'タスクが見つかりません' })
+    render(<TodoEditDialog {...defaultProps} />)
+
+    const submitButton = screen.getByRole('button', { name: '保存' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('タスクが見つかりません')).toBeInTheDocument()
+    })
+    expect(defaultProps.onOpenChange).not.toHaveBeenCalledWith(false)
+  })
+
+  it('should close dialog when cancel button is clicked', () => {
+    render(<TodoEditDialog {...defaultProps} />)
+
+    const cancelButton = screen.getByRole('button', { name: 'キャンセル' })
+    fireEvent.click(cancelButton)
+
+    expect(defaultProps.onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/__tests__/components/todo/TodoList.test.tsx
+++ b/__tests__/components/todo/TodoList.test.tsx
@@ -1,6 +1,13 @@
 import { render, screen } from '@testing-library/react'
 import { TodoList } from '@/components/todo/TodoList'
 
+// Mock the actions used by TodoItem
+jest.mock('@/actions/todo', () => ({
+  toggleTodoComplete: jest.fn(),
+  updateTodo: jest.fn(),
+  deleteTodo: jest.fn(),
+}))
+
 describe('TodoList', () => {
   const mockTodos = [
     {

--- a/__tests__/lib/validations/todo.test.ts
+++ b/__tests__/lib/validations/todo.test.ts
@@ -1,4 +1,4 @@
-import { createTodoSchema } from '@/lib/validations/todo'
+import { createTodoSchema, updateTodoSchema } from '@/lib/validations/todo'
 
 describe('createTodoSchema', () => {
   it('should validate correct todo data', () => {
@@ -97,5 +97,140 @@ describe('createTodoSchema', () => {
     }
     const result = createTodoSchema.safeParse(validData)
     expect(result.success).toBe(true)
+  })
+})
+
+describe('updateTodoSchema', () => {
+  const validData = {
+    id: 'todo-1',
+    title: 'タスク1',
+    memo: '',
+    isCompleted: false,
+  }
+
+  it('should validate correct update data', () => {
+    const result = updateTodoSchema.safeParse(validData)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.id).toBe('todo-1')
+      expect(result.data.title).toBe('タスク1')
+      expect(result.data.isCompleted).toBe(false)
+    }
+  })
+
+  it('should validate update data with memo', () => {
+    const data = {
+      ...validData,
+      memo: 'メモ内容',
+    }
+    const result = updateTodoSchema.safeParse(data)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.memo).toBe('メモ内容')
+    }
+  })
+
+  it('should validate completed todo', () => {
+    const data = {
+      ...validData,
+      isCompleted: true,
+    }
+    const result = updateTodoSchema.safeParse(data)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.isCompleted).toBe(true)
+    }
+  })
+
+  it('should transform empty memo to undefined', () => {
+    const data = {
+      ...validData,
+      memo: '',
+    }
+    const result = updateTodoSchema.safeParse(data)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.memo).toBeUndefined()
+    }
+  })
+
+  it('should reject empty id', () => {
+    const data = {
+      ...validData,
+      id: '',
+    }
+    const result = updateTodoSchema.safeParse(data)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('id')
+      expect(result.error.issues[0].message).toBe('IDが必要です')
+    }
+  })
+
+  it('should reject missing id', () => {
+    const { id: _id, ...dataWithoutId } = validData
+    const result = updateTodoSchema.safeParse(dataWithoutId)
+    expect(result.success).toBe(false)
+  })
+
+  it('should reject empty title', () => {
+    const data = {
+      ...validData,
+      title: '',
+    }
+    const result = updateTodoSchema.safeParse(data)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('title')
+      expect(result.error.issues[0].message).toBe('タイトルを入力してください')
+    }
+  })
+
+  it('should reject whitespace-only title', () => {
+    const data = {
+      ...validData,
+      title: '   ',
+    }
+    const result = updateTodoSchema.safeParse(data)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('title')
+      expect(result.error.issues[0].message).toBe('タイトルは空白のみでは登録できません')
+    }
+  })
+
+  it('should reject title longer than 100 characters', () => {
+    const data = {
+      ...validData,
+      title: 'a'.repeat(101),
+    }
+    const result = updateTodoSchema.safeParse(data)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('title')
+      expect(result.error.issues[0].message).toBe('タイトルは100文字以内で入力してください')
+    }
+  })
+
+  it('should reject memo longer than 1000 characters', () => {
+    const data = {
+      ...validData,
+      memo: 'a'.repeat(1001),
+    }
+    const result = updateTodoSchema.safeParse(data)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('memo')
+      expect(result.error.issues[0].message).toBe('メモは1000文字以内で入力してください')
+    }
+  })
+
+  it('should reject invalid isCompleted type', () => {
+    const data = {
+      ...validData,
+      isCompleted: 'true', // string instead of boolean
+    }
+    const result = updateTodoSchema.safeParse(data)
+    expect(result.success).toBe(false)
   })
 })

--- a/__tests__/lib/validations/todo.test.ts
+++ b/__tests__/lib/validations/todo.test.ts
@@ -168,6 +168,7 @@ describe('updateTodoSchema', () => {
   })
 
   it('should reject missing id', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { id: _id, ...dataWithoutId } = validData
     const result = updateTodoSchema.safeParse(dataWithoutId)
     expect(result.success).toBe(false)

--- a/actions/todo.ts
+++ b/actions/todo.ts
@@ -50,7 +50,7 @@ export async function createTodo(data: CreateTodoInput): Promise<CreateTodoResul
       data: {
         userId: session.user.id,
         title,
-        memo,
+        memo: memo ?? null,
       },
     })
 
@@ -111,7 +111,7 @@ export async function updateTodo(data: UpdateTodoInput): Promise<UpdateTodoResul
 
     const todo = await prisma.todo.update({
       where: { id },
-      data: { title, memo, isCompleted },
+      data: { title, memo: memo ?? null, isCompleted },
     })
 
     revalidatePath('/todos')

--- a/actions/todo.ts
+++ b/actions/todo.ts
@@ -3,7 +3,12 @@
 import { revalidatePath } from 'next/cache'
 import { prisma } from '@/lib/prisma'
 import { auth } from '@/lib/auth'
-import { createTodoSchema, type CreateTodoInput } from '@/lib/validations/todo'
+import {
+  createTodoSchema,
+  updateTodoSchema,
+  type CreateTodoInput,
+  type UpdateTodoInput,
+} from '@/lib/validations/todo'
 import type { TodoModel as Todo } from '@/src/generated/prisma/models'
 
 export type CreateTodoResult =
@@ -12,6 +17,18 @@ export type CreateTodoResult =
 
 export type GetTodosResult =
   | { success: true; todos: Todo[] }
+  | { success: false; error: string }
+
+export type UpdateTodoResult =
+  | { success: true; todo: Todo }
+  | { success: false; error: string }
+
+export type DeleteTodoResult =
+  | { success: true }
+  | { success: false; error: string }
+
+export type ToggleTodoCompleteResult =
+  | { success: true; todo: Todo }
   | { success: false; error: string }
 
 export async function createTodo(data: CreateTodoInput): Promise<CreateTodoResult> {
@@ -63,5 +80,118 @@ export async function getTodos(): Promise<GetTodosResult> {
   } catch (error) {
     console.error('Failed to fetch todos:', error)
     return { success: false, error: 'タスクの取得に失敗しました' }
+  }
+}
+
+export async function updateTodo(data: UpdateTodoInput): Promise<UpdateTodoResult> {
+  const session = await auth()
+
+  if (!session?.user?.id) {
+    return { success: false, error: '認証が必要です' }
+  }
+
+  const parsed = updateTodoSchema.safeParse(data)
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0].message }
+  }
+
+  const { id, title, memo, isCompleted } = parsed.data
+
+  try {
+    // Check if todo exists and belongs to user
+    const existingTodo = await prisma.todo.findUnique({
+      where: { id },
+      select: { userId: true },
+    })
+
+    // Return same error for both non-existent and unauthorized (security)
+    if (!existingTodo || existingTodo.userId !== session.user.id) {
+      return { success: false, error: 'タスクが見つかりません' }
+    }
+
+    const todo = await prisma.todo.update({
+      where: { id },
+      data: { title, memo, isCompleted },
+    })
+
+    revalidatePath('/todos')
+
+    return { success: true, todo }
+  } catch (error) {
+    console.error('Failed to update todo:', error)
+    return { success: false, error: 'タスクの更新に失敗しました' }
+  }
+}
+
+export async function deleteTodo(id: string): Promise<DeleteTodoResult> {
+  const session = await auth()
+
+  if (!session?.user?.id) {
+    return { success: false, error: '認証が必要です' }
+  }
+
+  if (!id) {
+    return { success: false, error: 'IDが必要です' }
+  }
+
+  try {
+    // Check if todo exists and belongs to user
+    const existingTodo = await prisma.todo.findUnique({
+      where: { id },
+      select: { userId: true },
+    })
+
+    // Return same error for both non-existent and unauthorized (security)
+    if (!existingTodo || existingTodo.userId !== session.user.id) {
+      return { success: false, error: 'タスクが見つかりません' }
+    }
+
+    await prisma.todo.delete({
+      where: { id },
+    })
+
+    revalidatePath('/todos')
+
+    return { success: true }
+  } catch (error) {
+    console.error('Failed to delete todo:', error)
+    return { success: false, error: 'タスクの削除に失敗しました' }
+  }
+}
+
+export async function toggleTodoComplete(id: string): Promise<ToggleTodoCompleteResult> {
+  const session = await auth()
+
+  if (!session?.user?.id) {
+    return { success: false, error: '認証が必要です' }
+  }
+
+  if (!id) {
+    return { success: false, error: 'IDが必要です' }
+  }
+
+  try {
+    // Check if todo exists and belongs to user
+    const existingTodo = await prisma.todo.findUnique({
+      where: { id },
+      select: { userId: true, isCompleted: true },
+    })
+
+    // Return same error for both non-existent and unauthorized (security)
+    if (!existingTodo || existingTodo.userId !== session.user.id) {
+      return { success: false, error: 'タスクが見つかりません' }
+    }
+
+    const todo = await prisma.todo.update({
+      where: { id },
+      data: { isCompleted: !existingTodo.isCompleted },
+    })
+
+    revalidatePath('/todos')
+
+    return { success: true, todo }
+  } catch (error) {
+    console.error('Failed to toggle todo:', error)
+    return { success: false, error: 'タスクの更新に失敗しました' }
   }
 }

--- a/components/todo/TodoDeleteDialog.tsx
+++ b/components/todo/TodoDeleteDialog.tsx
@@ -44,12 +44,20 @@ export function TodoDeleteDialog({
   }
 
   const handleCancel = () => {
-    setError(null)
     onOpenChange(false)
   }
 
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (nextOpen) {
+      // Reset state when dialog opens
+      setError(null)
+      setIsDeleting(false)
+    }
+    onOpenChange(nextOpen)
+  }
+
   return (
-    <AlertDialog open={open} onOpenChange={onOpenChange}>
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>タスクを削除</AlertDialogTitle>

--- a/components/todo/TodoDeleteDialog.tsx
+++ b/components/todo/TodoDeleteDialog.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { useState } from 'react'
+import { deleteTodo } from '@/actions/todo'
+import { Button } from '@/components/ui/button'
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+
+interface TodoDeleteDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  todoId: string
+  todoTitle: string
+}
+
+export function TodoDeleteDialog({
+  open,
+  onOpenChange,
+  todoId,
+  todoTitle,
+}: TodoDeleteDialogProps) {
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleDelete = async () => {
+    setIsDeleting(true)
+    setError(null)
+
+    const result = await deleteTodo(todoId)
+
+    if (result.success) {
+      onOpenChange(false)
+    } else {
+      setError(result.error)
+    }
+
+    setIsDeleting(false)
+  }
+
+  const handleCancel = () => {
+    setError(null)
+    onOpenChange(false)
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>タスクを削除</AlertDialogTitle>
+          <AlertDialogDescription>
+            「{todoTitle}」を削除しますか？この操作は取り消せません。
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        {error && (
+          <div className="p-3 text-sm text-red-500 bg-red-50 rounded-md">
+            {error}
+          </div>
+        )}
+
+        <AlertDialogFooter>
+          <Button variant="outline" onClick={handleCancel} disabled={isDeleting}>
+            キャンセル
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleDelete}
+            disabled={isDeleting}
+          >
+            {isDeleting ? '削除中...' : '削除'}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/components/todo/TodoEditDialog.tsx
+++ b/components/todo/TodoEditDialog.tsx
@@ -1,0 +1,152 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { updateTodoSchema, type UpdateTodoInput } from '@/lib/validations/todo'
+import { updateTodo } from '@/actions/todo'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+
+interface TodoEditDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  todo: {
+    id: string
+    title: string
+    memo: string | null
+    isCompleted: boolean
+  }
+}
+
+export function TodoEditDialog({ open, onOpenChange, todo }: TodoEditDialogProps) {
+  const [serverError, setServerError] = useState<string | null>(null)
+
+  const form = useForm<UpdateTodoInput>({
+    resolver: zodResolver(updateTodoSchema),
+    defaultValues: {
+      id: todo.id,
+      title: todo.title,
+      memo: todo.memo ?? '',
+      isCompleted: todo.isCompleted,
+    },
+  })
+
+  // Reset form when todo changes or dialog opens
+  useEffect(() => {
+    if (open) {
+      form.reset({
+        id: todo.id,
+        title: todo.title,
+        memo: todo.memo ?? '',
+        isCompleted: todo.isCompleted,
+      })
+      setServerError(null)
+    }
+  }, [open, todo, form])
+
+  const onSubmit = async (data: UpdateTodoInput) => {
+    setServerError(null)
+    const result = await updateTodo(data)
+    if (result.success) {
+      onOpenChange(false)
+    } else {
+      setServerError(result.error)
+    }
+  }
+
+  const handleCancel = () => {
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>タスクを編集</DialogTitle>
+          <DialogDescription>
+            タスクの内容を編集します
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4" noValidate>
+            {serverError && (
+              <div className="p-3 text-sm text-red-500 bg-red-50 rounded-md">
+                {serverError}
+              </div>
+            )}
+
+            <FormField
+              control={form.control}
+              name="title"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>タイトル</FormLabel>
+                  <FormControl>
+                    <Input placeholder="タスクを入力" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="memo"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>メモ（任意）</FormLabel>
+                  <FormControl>
+                    <Textarea placeholder="メモを入力（任意）" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="isCompleted"
+              render={({ field }) => (
+                <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+                  <FormControl>
+                    <Checkbox
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                  <FormLabel className="font-normal">完了</FormLabel>
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={handleCancel}>
+                キャンセル
+              </Button>
+              <Button type="submit">保存</Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/todo/TodoEditDialog.tsx
+++ b/components/todo/TodoEditDialog.tsx
@@ -59,9 +59,16 @@ export function TodoEditDialog({ open, onOpenChange, todo }: TodoEditDialogProps
         memo: todo.memo ?? '',
         isCompleted: todo.isCompleted,
       })
-      setServerError(null)
     }
   }, [open, todo, form])
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (nextOpen) {
+      // Reset error when dialog opens
+      setServerError(null)
+    }
+    onOpenChange(nextOpen)
+  }
 
   const onSubmit = async (data: UpdateTodoInput) => {
     setServerError(null)
@@ -78,7 +85,7 @@ export function TodoEditDialog({ open, onOpenChange, todo }: TodoEditDialogProps
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>タスクを編集</DialogTitle>

--- a/components/todo/TodoItem.tsx
+++ b/components/todo/TodoItem.tsx
@@ -1,4 +1,12 @@
+'use client'
+
+import { useState } from 'react'
 import { cn } from '@/lib/utils'
+import { toggleTodoComplete } from '@/actions/todo'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { TodoEditDialog } from './TodoEditDialog'
+import { TodoDeleteDialog } from './TodoDeleteDialog'
 
 interface TodoItemProps {
   id: string
@@ -7,32 +15,78 @@ interface TodoItemProps {
   memo: string | null
 }
 
-export function TodoItem({ title, isCompleted, memo }: TodoItemProps) {
+export function TodoItem({ id, title, isCompleted, memo }: TodoItemProps) {
+  const [editOpen, setEditOpen] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
+
+  const handleToggle = async () => {
+    await toggleTodoComplete(id)
+  }
+
   return (
     <div className="border rounded-lg p-4 bg-card">
-      <div className="flex items-center justify-between">
-        <h3
-          className={cn(
-            'font-medium',
-            isCompleted && 'line-through text-muted-foreground'
+      <div className="flex items-center gap-3">
+        <Checkbox
+          checked={isCompleted}
+          onCheckedChange={handleToggle}
+          aria-label={isCompleted ? '未完了にする' : '完了にする'}
+        />
+        <div className="flex-1">
+          <div className="flex items-center justify-between">
+            <h3
+              className={cn(
+                'font-medium',
+                isCompleted && 'line-through text-muted-foreground'
+              )}
+            >
+              {title}
+            </h3>
+            <span
+              className={cn(
+                'text-xs px-2 py-1 rounded-full',
+                isCompleted
+                  ? 'bg-green-100 text-green-700'
+                  : 'bg-yellow-100 text-yellow-700'
+              )}
+            >
+              {isCompleted ? '完了' : '未完了'}
+            </span>
+          </div>
+          {memo && (
+            <p className="text-sm text-muted-foreground mt-2">{memo}</p>
           )}
-        >
-          {title}
-        </h3>
-        <span
-          className={cn(
-            'text-xs px-2 py-1 rounded-full',
-            isCompleted
-              ? 'bg-green-100 text-green-700'
-              : 'bg-yellow-100 text-yellow-700'
-          )}
-        >
-          {isCompleted ? '完了' : '未完了'}
-        </span>
+        </div>
       </div>
-      {memo && (
-        <p className="text-sm text-muted-foreground mt-2">{memo}</p>
-      )}
+
+      <div className="flex gap-2 mt-3 justify-end">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setEditOpen(true)}
+        >
+          編集
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setDeleteOpen(true)}
+        >
+          削除
+        </Button>
+      </div>
+
+      <TodoEditDialog
+        open={editOpen}
+        onOpenChange={setEditOpen}
+        todo={{ id, title, memo, isCompleted }}
+      />
+
+      <TodoDeleteDialog
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        todoId={id}
+        todoTitle={title}
+      />
     </div>
   )
 }

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -1,0 +1,155 @@
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("text-lg font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action
+      className={cn(buttonVariants(), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: "outline" }), className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { CheckIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,8 @@
 import '@testing-library/jest-dom'
+
+// Mock ResizeObserver for radix-ui components
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,4 +1,9 @@
 import '@testing-library/jest-dom'
+import { TextEncoder, TextDecoder } from 'util'
+
+// Polyfill TextEncoder/TextDecoder for next/cache
+global.TextEncoder = TextEncoder
+global.TextDecoder = TextDecoder as typeof global.TextDecoder
 
 // Mock ResizeObserver for radix-ui components
 global.ResizeObserver = class ResizeObserver {

--- a/lib/validations/todo.ts
+++ b/lib/validations/todo.ts
@@ -1,20 +1,35 @@
 import { z } from 'zod'
 
+// 共通フィールド定義
+const titleField = z
+  .string()
+  .min(1, 'タイトルを入力してください')
+  .max(100, 'タイトルは100文字以内で入力してください')
+  .transform((val) => val.trim())
+  .refine((val) => val.length > 0, {
+    message: 'タイトルは空白のみでは登録できません',
+  })
+
+const memoField = z
+  .string()
+  .max(1000, 'メモは1000文字以内で入力してください')
+  .optional()
+  .transform((val) => (val?.trim() || undefined))
+
 export const createTodoSchema = z.object({
-  title: z
-    .string()
-    .min(1, 'タイトルを入力してください')
-    .max(100, 'タイトルは100文字以内で入力してください')
-    .transform((val) => val.trim())
-    .refine((val) => val.length > 0, {
-      message: 'タイトルは空白のみでは登録できません',
-    }),
-  memo: z
-    .string()
-    .max(1000, 'メモは1000文字以内で入力してください')
-    .optional()
-    .transform((val) => (val?.trim() || undefined)),
+  title: titleField,
+  memo: memoField,
 })
 
 export type CreateTodoInput = z.input<typeof createTodoSchema>
 export type CreateTodoOutput = z.output<typeof createTodoSchema>
+
+export const updateTodoSchema = z.object({
+  id: z.string().min(1, 'IDが必要です'),
+  title: titleField,
+  memo: memoField,
+  isCompleted: z.boolean(),
+})
+
+export type UpdateTodoInput = z.input<typeof updateTodoSchema>
+export type UpdateTodoOutput = z.output<typeof updateTodoSchema>

--- a/lib/validations/todo.ts
+++ b/lib/validations/todo.ts
@@ -14,7 +14,7 @@ const memoField = z
   .string()
   .max(1000, 'メモは1000文字以内で入力してください')
   .optional()
-  .transform((val) => (val?.trim() || undefined))
+  .transform((val) => val?.trim() || undefined)
 
 export const createTodoSchema = z.object({
   title: titleField,

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@hookform/resolvers": "^5.2.2",
         "@prisma/adapter-pg": "^7.2.0",
         "@prisma/client": "^7.2.0",
+        "@radix-ui/react-alert-dialog": "^1.1.15",
+        "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-slot": "^1.2.4",
@@ -2596,6 +2598,146 @@
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
@@ -3098,6 +3240,39 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
       "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
       "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "@hookform/resolvers": "^5.2.2",
     "@prisma/adapter-pg": "^7.2.0",
     "@prisma/client": "^7.2.0",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
+    "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-slot": "^1.2.4",


### PR DESCRIPTION
## Summary
- ToDoの編集・削除機能を実装
- TDDアプローチでテストを先に書いてから実装
- 認証・認可チェックを全Server Actionに実装

## 変更内容
- **Phase 1**: `updateTodoSchema`バリデーション追加
- **Phase 2**: `updateTodo`, `deleteTodo`, `toggleTodoComplete` Server Actions追加
- **Phase 3**: `TodoEditDialog`, `TodoDeleteDialog`コンポーネント追加
- **Phase 4**: `TodoItem`に編集/削除/完了トグル機能追加

## セキュリティ
- 全Server Actionで`session.user.id`による認証チェック
- 所有者確認で他ユーザーのTodo操作を防止
- 存在しない/他人のTodoで同じエラーメッセージを返す（情報漏洩防止）

## Codex Review
- [x] Codex MCPによるコードレビュー完了
- [x] 全ての指摘事項を修正済み

## Test Plan
- [x] テストが全てパスする（153テスト）
- [x] 新規テストを追加した
- [x] lint/型エラーがない

Closes #10

🤖 Generated with [Claude Code](https://claude.ai/code)