### PR TITLE
feat: Todoフィルタ機能（全件/未完了/完了）を追加

### DIFF
--- a/__tests__/components/todo/TodoFilter.test.tsx
+++ b/__tests__/components/todo/TodoFilter.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { TodoFilter } from '@/components/todo/TodoFilter'
+
+describe('TodoFilter', () => {
+  const defaultCounts = {
+    all: 5,
+    incomplete: 3,
+    completed: 2,
+  }
+
+  const mockOnFilterChange = jest.fn()
+
+  beforeEach(() => {
+    mockOnFilterChange.mockClear()
+  })
+
+  it('should render three filter buttons', () => {
+    render(
+      <TodoFilter
+        currentFilter="all"
+        onFilterChange={mockOnFilterChange}
+        counts={defaultCounts}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: /全件 \(/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /未完了 \(/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^完了 \(/ })).toBeInTheDocument()
+  })
+
+  it('should display counts for each filter', () => {
+    render(
+      <TodoFilter
+        currentFilter="all"
+        onFilterChange={mockOnFilterChange}
+        counts={defaultCounts}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: /全件 \(5\)/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /未完了 \(3\)/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /完了 \(2\)/ })).toBeInTheDocument()
+  })
+
+  it('should call onFilterChange with "all" when all button is clicked', () => {
+    render(
+      <TodoFilter
+        currentFilter="incomplete"
+        onFilterChange={mockOnFilterChange}
+        counts={defaultCounts}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /全件/ }))
+
+    expect(mockOnFilterChange).toHaveBeenCalledWith('all')
+  })
+
+  it('should call onFilterChange with "incomplete" when incomplete button is clicked', () => {
+    render(
+      <TodoFilter
+        currentFilter="all"
+        onFilterChange={mockOnFilterChange}
+        counts={defaultCounts}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /未完了/ }))
+
+    expect(mockOnFilterChange).toHaveBeenCalledWith('incomplete')
+  })
+
+  it('should call onFilterChange with "completed" when completed button is clicked', () => {
+    render(
+      <TodoFilter
+        currentFilter="all"
+        onFilterChange={mockOnFilterChange}
+        counts={defaultCounts}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /^完了 \(/ }))
+
+    expect(mockOnFilterChange).toHaveBeenCalledWith('completed')
+  })
+
+  it('should highlight the active filter button', () => {
+    const { rerender } = render(
+      <TodoFilter
+        currentFilter="all"
+        onFilterChange={mockOnFilterChange}
+        counts={defaultCounts}
+      />
+    )
+
+    const allButton = screen.getByRole('button', { name: /全件 \(/ })
+    const incompleteButton = screen.getByRole('button', { name: /未完了 \(/ })
+    const completedButton = screen.getByRole('button', { name: /^完了 \(/ })
+
+    // "all" is active
+    expect(allButton).toHaveAttribute('data-active', 'true')
+    expect(incompleteButton).toHaveAttribute('data-active', 'false')
+    expect(completedButton).toHaveAttribute('data-active', 'false')
+
+    // Change to "incomplete"
+    rerender(
+      <TodoFilter
+        currentFilter="incomplete"
+        onFilterChange={mockOnFilterChange}
+        counts={defaultCounts}
+      />
+    )
+
+    expect(allButton).toHaveAttribute('data-active', 'false')
+    expect(incompleteButton).toHaveAttribute('data-active', 'true')
+    expect(completedButton).toHaveAttribute('data-active', 'false')
+
+    // Change to "completed"
+    rerender(
+      <TodoFilter
+        currentFilter="completed"
+        onFilterChange={mockOnFilterChange}
+        counts={defaultCounts}
+      />
+    )
+
+    expect(allButton).toHaveAttribute('data-active', 'false')
+    expect(incompleteButton).toHaveAttribute('data-active', 'false')
+    expect(completedButton).toHaveAttribute('data-active', 'true')
+  })
+})

--- a/__tests__/components/todo/TodoFilter.test.tsx
+++ b/__tests__/components/todo/TodoFilter.test.tsx
@@ -98,9 +98,9 @@ describe('TodoFilter', () => {
     const completedButton = screen.getByRole('button', { name: /^完了 \(/ })
 
     // "all" is active
-    expect(allButton).toHaveAttribute('data-active', 'true')
-    expect(incompleteButton).toHaveAttribute('data-active', 'false')
-    expect(completedButton).toHaveAttribute('data-active', 'false')
+    expect(allButton).toHaveAttribute('aria-pressed', 'true')
+    expect(incompleteButton).toHaveAttribute('aria-pressed', 'false')
+    expect(completedButton).toHaveAttribute('aria-pressed', 'false')
 
     // Change to "incomplete"
     rerender(
@@ -111,9 +111,9 @@ describe('TodoFilter', () => {
       />
     )
 
-    expect(allButton).toHaveAttribute('data-active', 'false')
-    expect(incompleteButton).toHaveAttribute('data-active', 'true')
-    expect(completedButton).toHaveAttribute('data-active', 'false')
+    expect(allButton).toHaveAttribute('aria-pressed', 'false')
+    expect(incompleteButton).toHaveAttribute('aria-pressed', 'true')
+    expect(completedButton).toHaveAttribute('aria-pressed', 'false')
 
     // Change to "completed"
     rerender(
@@ -124,8 +124,8 @@ describe('TodoFilter', () => {
       />
     )
 
-    expect(allButton).toHaveAttribute('data-active', 'false')
-    expect(incompleteButton).toHaveAttribute('data-active', 'false')
-    expect(completedButton).toHaveAttribute('data-active', 'true')
+    expect(allButton).toHaveAttribute('aria-pressed', 'false')
+    expect(incompleteButton).toHaveAttribute('aria-pressed', 'false')
+    expect(completedButton).toHaveAttribute('aria-pressed', 'true')
   })
 })

--- a/__tests__/components/todo/TodoList.test.tsx
+++ b/__tests__/components/todo/TodoList.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { TodoList } from '@/components/todo/TodoList'
 
 // Mock the actions used by TodoItem
@@ -54,5 +54,104 @@ describe('TodoList', () => {
 
     expect(screen.getByText('未完了')).toBeInTheDocument()
     expect(screen.getByText('完了')).toBeInTheDocument()
+  })
+
+  describe('Filter functionality', () => {
+    const todosForFilter = [
+      {
+        id: 'todo-1',
+        userId: 'user-1',
+        title: 'タスク1（未完了）',
+        memo: null,
+        isCompleted: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: 'todo-2',
+        userId: 'user-1',
+        title: 'タスク2（完了）',
+        memo: null,
+        isCompleted: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: 'todo-3',
+        userId: 'user-1',
+        title: 'タスク3（未完了）',
+        memo: null,
+        isCompleted: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]
+
+    it('should render filter buttons', () => {
+      render(<TodoList todos={todosForFilter} />)
+
+      expect(screen.getByRole('button', { name: /全件 \(/ })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /未完了 \(/ })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /^完了 \(/ })).toBeInTheDocument()
+    })
+
+    it('should show correct counts in filter buttons', () => {
+      render(<TodoList todos={todosForFilter} />)
+
+      expect(screen.getByRole('button', { name: /全件 \(3\)/ })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /未完了 \(2\)/ })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /^完了 \(1\)/ })).toBeInTheDocument()
+    })
+
+    it('should show all todos by default', () => {
+      render(<TodoList todos={todosForFilter} />)
+
+      expect(screen.getByText('タスク1（未完了）')).toBeInTheDocument()
+      expect(screen.getByText('タスク2（完了）')).toBeInTheDocument()
+      expect(screen.getByText('タスク3（未完了）')).toBeInTheDocument()
+    })
+
+    it('should show only incomplete todos when incomplete filter is clicked', () => {
+      render(<TodoList todos={todosForFilter} />)
+
+      fireEvent.click(screen.getByRole('button', { name: /未完了 \(/ }))
+
+      expect(screen.getByText('タスク1（未完了）')).toBeInTheDocument()
+      expect(screen.queryByText('タスク2（完了）')).not.toBeInTheDocument()
+      expect(screen.getByText('タスク3（未完了）')).toBeInTheDocument()
+    })
+
+    it('should show only completed todos when completed filter is clicked', () => {
+      render(<TodoList todos={todosForFilter} />)
+
+      fireEvent.click(screen.getByRole('button', { name: /^完了 \(/ }))
+
+      expect(screen.queryByText('タスク1（未完了）')).not.toBeInTheDocument()
+      expect(screen.getByText('タスク2（完了）')).toBeInTheDocument()
+      expect(screen.queryByText('タスク3（未完了）')).not.toBeInTheDocument()
+    })
+
+    it('should show all todos when all filter is clicked after another filter', () => {
+      render(<TodoList todos={todosForFilter} />)
+
+      // First, filter to incomplete
+      fireEvent.click(screen.getByRole('button', { name: /未完了 \(/ }))
+      expect(screen.queryByText('タスク2（完了）')).not.toBeInTheDocument()
+
+      // Then, click all filter
+      fireEvent.click(screen.getByRole('button', { name: /全件 \(/ }))
+
+      expect(screen.getByText('タスク1（未完了）')).toBeInTheDocument()
+      expect(screen.getByText('タスク2（完了）')).toBeInTheDocument()
+      expect(screen.getByText('タスク3（未完了）')).toBeInTheDocument()
+    })
+
+    it('should not render filter buttons when todos is empty', () => {
+      render(<TodoList todos={[]} />)
+
+      expect(screen.queryByRole('button', { name: /全件/ })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /未完了/ })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /^完了/ })).not.toBeInTheDocument()
+    })
   })
 })

--- a/components/todo/TodoFilter.tsx
+++ b/components/todo/TodoFilter.tsx
@@ -35,7 +35,7 @@ export function TodoFilter({
             variant={isActive ? 'default' : 'outline'}
             size="sm"
             onClick={() => onFilterChange(type)}
-            data-active={isActive}
+            aria-pressed={isActive}
           >
             {label} ({counts[type]})
           </Button>

--- a/components/todo/TodoFilter.tsx
+++ b/components/todo/TodoFilter.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+
+export type FilterType = 'all' | 'incomplete' | 'completed'
+
+interface TodoFilterProps {
+  currentFilter: FilterType
+  onFilterChange: (filter: FilterType) => void
+  counts: {
+    all: number
+    incomplete: number
+    completed: number
+  }
+}
+
+export function TodoFilter({
+  currentFilter,
+  onFilterChange,
+  counts,
+}: TodoFilterProps) {
+  const filters: { type: FilterType; label: string }[] = [
+    { type: 'all', label: '全件' },
+    { type: 'incomplete', label: '未完了' },
+    { type: 'completed', label: '完了' },
+  ]
+
+  return (
+    <div className="flex gap-2 mb-4">
+      {filters.map(({ type, label }) => {
+        const isActive = currentFilter === type
+        return (
+          <Button
+            key={type}
+            variant={isActive ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => onFilterChange(type)}
+            data-active={isActive}
+          >
+            {label} ({counts[type]})
+          </Button>
+        )
+      })}
+    </div>
+  )
+}

--- a/components/todo/TodoList.tsx
+++ b/components/todo/TodoList.tsx
@@ -1,11 +1,37 @@
+'use client'
+
+import { useMemo, useState } from 'react'
 import type { TodoModel as Todo } from '@/src/generated/prisma/models'
 import { TodoItem } from './TodoItem'
+import { TodoFilter, type FilterType } from './TodoFilter'
 
 interface TodoListProps {
   todos: Todo[]
 }
 
 export function TodoList({ todos }: TodoListProps) {
+  const [filter, setFilter] = useState<FilterType>('all')
+
+  const counts = useMemo(
+    () => ({
+      all: todos.length,
+      incomplete: todos.filter((todo) => !todo.isCompleted).length,
+      completed: todos.filter((todo) => todo.isCompleted).length,
+    }),
+    [todos]
+  )
+
+  const filteredTodos = useMemo(() => {
+    switch (filter) {
+      case 'incomplete':
+        return todos.filter((todo) => !todo.isCompleted)
+      case 'completed':
+        return todos.filter((todo) => todo.isCompleted)
+      default:
+        return todos
+    }
+  }, [todos, filter])
+
   if (todos.length === 0) {
     return (
       <div className="text-center py-12 text-muted-foreground max-w-2xl mx-auto">
@@ -15,16 +41,23 @@ export function TodoList({ todos }: TodoListProps) {
   }
 
   return (
-    <div className="space-y-3 max-w-2xl mx-auto">
-      {todos.map((todo) => (
-        <TodoItem
-          key={todo.id}
-          id={todo.id}
-          title={todo.title}
-          isCompleted={todo.isCompleted}
-          memo={todo.memo}
-        />
-      ))}
+    <div className="max-w-2xl mx-auto">
+      <TodoFilter
+        currentFilter={filter}
+        onFilterChange={setFilter}
+        counts={counts}
+      />
+      <div className="space-y-3">
+        {filteredTodos.map((todo) => (
+          <TodoItem
+            key={todo.id}
+            id={todo.id}
+            title={todo.title}
+            isCompleted={todo.isCompleted}
+            memo={todo.memo}
+          />
+        ))}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- TodoFilter コンポーネントを新規作成（ボタングループ形式）
- TodoList にフィルタ状態管理とロジックを統合
- 各フィルタに件数を表示（例: 「未完了 (3)」）
- アクセシビリティ対応（aria-pressed属性）

## Codex Review
- [x] Codex MCPによるコードレビュー完了
- [x] 全ての指摘事項を修正済み

## Test Plan
- [x] テストが全てパスする（166 tests）
- [x] 新規テストを追加した（TodoFilter: 6件、TodoList Filter: 7件）
- [x] lint/型エラーがない

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)