### PR TITLE
feat: ヘッダーにメールアドレスとToDo一覧リンクを追加

### DIFF
--- a/__tests__/components/Header.test.tsx
+++ b/__tests__/components/Header.test.tsx
@@ -83,6 +83,36 @@ describe('Header', () => {
       render(await Header())
       expect(screen.queryByRole('link', { name: 'ログイン' })).not.toBeInTheDocument()
     })
+
+    it('should not render email when user email is not available', async () => {
+      mockAuth.mockResolvedValue({
+        user: {
+          id: 'user-1',
+          name: 'Test User',
+        },
+      })
+      render(await Header())
+      const emailElements = document.querySelectorAll('.text-muted-foreground')
+      expect(emailElements.length).toBe(0)
+    })
+
+    it('should display user email address', async () => {
+      render(await Header())
+      const emailElement = screen.getByText('test@example.com')
+      expect(emailElement).toBeInTheDocument()
+    })
+
+    it('should hide email on mobile with hidden sm:block classes', async () => {
+      render(await Header())
+      const emailElement = screen.getByText('test@example.com')
+      expect(emailElement).toHaveClass('hidden', 'sm:block')
+    })
+
+    it('should render ToDo一覧 link', async () => {
+      render(await Header())
+      const link = screen.getByRole('link', { name: 'ToDo一覧' })
+      expect(link).toHaveAttribute('href', '/todos')
+    })
   })
 
   it('should have sticky class for fixed positioning', async () => {

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -16,11 +16,21 @@ export async function Header() {
         </Link>
         <div className="flex items-center gap-2">
           {session ? (
-            <form action={logout}>
-              <Button type="submit" variant="outline">
-                ログアウト
+            <>
+              {session.user?.email && (
+                <span className="hidden text-sm text-muted-foreground sm:block">
+                  {session.user.email}
+                </span>
+              )}
+              <Button variant="ghost" asChild>
+                <Link href="/todos">ToDo一覧</Link>
               </Button>
-            </form>
+              <form action={logout}>
+                <Button type="submit" variant="outline">
+                  ログアウト
+                </Button>
+              </form>
+            </>
           ) : (
             <>
               <Button variant="default" asChild>


### PR DESCRIPTION
## Summary

- ログイン時にユーザーのメールアドレスをヘッダーに表示
- モバイルではメールアドレスを非表示（レスポンシブ対応）
- ToDo一覧（/todos）への遷移ボタンを追加
- メールアドレスが存在しない場合のガード処理を追加

Closes #14

## Codex Review

- [x] Codex MCPによるコードレビュー完了
- [x] 全ての指摘事項を修正済み
  - メールアドレスのガード処理追加
  - モバイル非表示のテスト追加
  - メールがない場合のテスト追加

## Test Plan

- [x] `npm run test -- Header` - 全14テストがパス
- [x] 新規テストを4件追加
  - should not render email when user email is not available
  - should display user email address
  - should hide email on mobile with hidden sm:block classes
  - should render ToDo一覧 link
- [x] `npm run lint` - エラーなし
- [x] `npx tsc --noEmit` - 型エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)