### PR TITLE
feat: プロフィール編集機能を追加

### DIFF
--- a/__tests__/actions/profile.test.ts
+++ b/__tests__/actions/profile.test.ts
@@ -176,7 +176,7 @@ describe('updateProfile action', () => {
     expect(result.error).toBe('このメールアドレスは既に使用されています')
   })
 
-  it('P2002エラーでtarget情報がない場合もエラーメッセージを返す（フォールバック）', async () => {
+  it('P2002エラーでtarget情報がない場合は汎用エラーメッセージを返す', async () => {
     mockAuth.mockResolvedValue({
       user: { id: 'user-1', email: 'old@example.com', name: 'Name' },
       expires: new Date().toISOString(),
@@ -192,10 +192,10 @@ describe('updateProfile action', () => {
     })
 
     expect(result.success).toBe(false)
-    expect(result.error).toBe('このメールアドレスは既に使用されています')
+    expect(result.error).toBe('一意制約違反が発生しました')
   })
 
-  it('P2002エラーで複合キー（emailを含む）の場合もエラーを返す', async () => {
+  it('P2002エラーで複合キー（emailを含む）の場合はemailエラーを返す', async () => {
     mockAuth.mockResolvedValue({
       user: { id: 'user-1', email: 'old@example.com', name: 'Name' },
       expires: new Date().toISOString(),
@@ -212,6 +212,25 @@ describe('updateProfile action', () => {
 
     expect(result.success).toBe(false)
     expect(result.error).toBe('このメールアドレスは既に使用されています')
+  })
+
+  it('P2002エラーでemail以外の制約違反の場合は汎用エラーを返す', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'old@example.com', name: 'Name' },
+      expires: new Date().toISOString(),
+    })
+    mockPrisma.user.findUnique.mockResolvedValue(null)
+    const p2002Error = new Error('Unique constraint failed')
+    Object.assign(p2002Error, { code: 'P2002', meta: { target: ['other_field'] } })
+    mockPrisma.user.update.mockRejectedValue(p2002Error)
+
+    const result = await updateProfile({
+      name: 'Name',
+      email: 'test@example.com',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('一意制約違反が発生しました')
   })
 
   it('emailが小文字に正規化されて保存される', async () => {

--- a/__tests__/actions/profile.test.ts
+++ b/__tests__/actions/profile.test.ts
@@ -27,7 +27,8 @@ import { auth } from '@/lib/auth'
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockPrisma = prisma as any
 const mockBcrypt = bcrypt as jest.Mocked<typeof bcrypt>
-const mockAuth = auth as jest.MockedFunction<typeof auth>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockAuth = auth as any
 
 describe('updateProfile action', () => {
   beforeEach(() => {

--- a/__tests__/actions/profile.test.ts
+++ b/__tests__/actions/profile.test.ts
@@ -1,0 +1,299 @@
+import { updateProfile, changePassword } from '@/actions/profile'
+
+// Mock modules
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}))
+
+jest.mock('bcryptjs', () => ({
+  hash: jest.fn(),
+  compare: jest.fn(),
+}))
+
+jest.mock('@/lib/auth', () => ({
+  auth: jest.fn(),
+}))
+
+// Import mocks after jest.mock
+import { prisma } from '@/lib/prisma'
+import bcrypt from 'bcryptjs'
+import { auth } from '@/lib/auth'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockPrisma = prisma as any
+const mockBcrypt = bcrypt as jest.Mocked<typeof bcrypt>
+const mockAuth = auth as jest.MockedFunction<typeof auth>
+
+describe('updateProfile action', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('セッションがない場合、エラーを返す', async () => {
+    mockAuth.mockResolvedValue(null)
+
+    const result = await updateProfile({
+      name: 'テストユーザー',
+      email: 'test@example.com',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('認証が必要です')
+  })
+
+  it('nameとemailを更新できる', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'old@example.com', name: 'Old Name' },
+      expires: new Date().toISOString(),
+    })
+    mockPrisma.user.findUnique.mockResolvedValue(null)
+    mockPrisma.user.update.mockResolvedValue({
+      id: 'user-1',
+      email: 'new@example.com',
+      name: 'New Name',
+    })
+
+    const result = await updateProfile({
+      name: 'New Name',
+      email: 'new@example.com',
+    })
+
+    expect(result.success).toBe(true)
+    expect(mockPrisma.user.update).toHaveBeenCalledWith({
+      where: { id: 'user-1' },
+      data: { name: 'New Name', email: 'new@example.com' },
+    })
+  })
+
+  it('nameを空にすることができる', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'test@example.com', name: 'Old Name' },
+      expires: new Date().toISOString(),
+    })
+    mockPrisma.user.findUnique.mockResolvedValue(null)
+    mockPrisma.user.update.mockResolvedValue({
+      id: 'user-1',
+      email: 'test@example.com',
+      name: '',
+    })
+
+    const result = await updateProfile({
+      name: '',
+      email: 'test@example.com',
+    })
+
+    expect(result.success).toBe(true)
+    expect(mockPrisma.user.update).toHaveBeenCalledWith({
+      where: { id: 'user-1' },
+      data: { name: '', email: 'test@example.com' },
+    })
+  })
+
+  it('同じemailに変更する場合（自分自身）は成功する', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'test@example.com', name: 'Name' },
+      expires: new Date().toISOString(),
+    })
+    // 自分自身が見つかる
+    mockPrisma.user.findUnique.mockResolvedValue({
+      id: 'user-1',
+      email: 'test@example.com',
+    })
+    mockPrisma.user.update.mockResolvedValue({
+      id: 'user-1',
+      email: 'test@example.com',
+      name: 'New Name',
+    })
+
+    const result = await updateProfile({
+      name: 'New Name',
+      email: 'test@example.com',
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('既に使用されているemailに変更しようとするとエラーを返す', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'old@example.com', name: 'Name' },
+      expires: new Date().toISOString(),
+    })
+    // 別のユーザーが見つかる
+    mockPrisma.user.findUnique.mockResolvedValue({
+      id: 'user-2',
+      email: 'existing@example.com',
+    })
+
+    const result = await updateProfile({
+      name: 'Name',
+      email: 'existing@example.com',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('このメールアドレスは既に使用されています')
+    expect(mockPrisma.user.update).not.toHaveBeenCalled()
+  })
+
+  it('無効なemailの場合、バリデーションエラーを返す', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'old@example.com', name: 'Name' },
+      expires: new Date().toISOString(),
+    })
+
+    const result = await updateProfile({
+      name: 'Name',
+      email: 'invalid-email',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('有効なメールアドレスを入力してください')
+  })
+})
+
+describe('changePassword action', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('セッションがない場合、エラーを返す', async () => {
+    mockAuth.mockResolvedValue(null)
+
+    const result = await changePassword({
+      currentPassword: 'oldpass123',
+      newPassword: 'newpass123',
+      confirmNewPassword: 'newpass123',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('認証が必要です')
+  })
+
+  it('パスワードがnullの場合（OAuth認証のみ）、エラーを返す', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'test@example.com' },
+      expires: new Date().toISOString(),
+    })
+    mockPrisma.user.findUnique.mockResolvedValue({
+      id: 'user-1',
+      email: 'test@example.com',
+      password: null,
+    })
+
+    const result = await changePassword({
+      currentPassword: 'oldpass123',
+      newPassword: 'newpass123',
+      confirmNewPassword: 'newpass123',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('パスワードが設定されていません')
+  })
+
+  it('現在のパスワードが間違っている場合、エラーを返す', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'test@example.com' },
+      expires: new Date().toISOString(),
+    })
+    mockPrisma.user.findUnique.mockResolvedValue({
+      id: 'user-1',
+      email: 'test@example.com',
+      password: 'hashed_password',
+    })
+    mockBcrypt.compare.mockResolvedValue(false as never)
+
+    const result = await changePassword({
+      currentPassword: 'wrongpass',
+      newPassword: 'newpass123',
+      confirmNewPassword: 'newpass123',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('現在のパスワードが正しくありません')
+  })
+
+  it('新しいパスワードに変更できる', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'test@example.com' },
+      expires: new Date().toISOString(),
+    })
+    mockPrisma.user.findUnique.mockResolvedValue({
+      id: 'user-1',
+      email: 'test@example.com',
+      password: 'hashed_old_password',
+    })
+    mockBcrypt.compare.mockResolvedValue(true as never)
+    mockBcrypt.hash.mockResolvedValue('hashed_new_password' as never)
+    mockPrisma.user.update.mockResolvedValue({
+      id: 'user-1',
+      email: 'test@example.com',
+      password: 'hashed_new_password',
+    })
+
+    const result = await changePassword({
+      currentPassword: 'oldpass123',
+      newPassword: 'newpass123',
+      confirmNewPassword: 'newpass123',
+    })
+
+    expect(result.success).toBe(true)
+    expect(mockBcrypt.compare).toHaveBeenCalledWith('oldpass123', 'hashed_old_password')
+    expect(mockBcrypt.hash).toHaveBeenCalledWith('newpass123', 12)
+    expect(mockPrisma.user.update).toHaveBeenCalledWith({
+      where: { id: 'user-1' },
+      data: { password: 'hashed_new_password' },
+    })
+  })
+
+  it('新しいパスワードが8文字未満の場合、バリデーションエラーを返す', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'test@example.com' },
+      expires: new Date().toISOString(),
+    })
+
+    const result = await changePassword({
+      currentPassword: 'oldpass123',
+      newPassword: 'short1',
+      confirmNewPassword: 'short1',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('パスワードは8文字以上で入力してください')
+  })
+
+  it('新しいパスワードに英字が含まれない場合、バリデーションエラーを返す', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'test@example.com' },
+      expires: new Date().toISOString(),
+    })
+
+    const result = await changePassword({
+      currentPassword: 'oldpass123',
+      newPassword: '12345678',
+      confirmNewPassword: '12345678',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('パスワードには英字と数字を含めてください')
+  })
+
+  it('新しいパスワードと確認用が一致しない場合、バリデーションエラーを返す', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: 'user-1', email: 'test@example.com' },
+      expires: new Date().toISOString(),
+    })
+
+    const result = await changePassword({
+      currentPassword: 'oldpass123',
+      newPassword: 'newpass123',
+      confirmNewPassword: 'different123',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('新しいパスワードが一致しません')
+  })
+})

--- a/__tests__/components/Header.test.tsx
+++ b/__tests__/components/Header.test.tsx
@@ -7,9 +7,13 @@ jest.mock('@/lib/auth', () => ({
   auth: () => mockAuth(),
 }))
 
-// Mock the logout action
-jest.mock('@/actions/auth', () => ({
-  logout: jest.fn(),
+// Mock the UserMenu component
+jest.mock('@/components/UserMenu', () => ({
+  UserMenu: ({ name, email }: { name: string | null; email: string }) => (
+    <div data-testid="user-menu">
+      <span data-testid="user-display-name">{name || email}</span>
+    </div>
+  ),
 }))
 
 describe('Header', () => {
@@ -51,9 +55,9 @@ describe('Header', () => {
       expect(link).toHaveAttribute('href', '/login')
     })
 
-    it('should not render logout button', async () => {
+    it('should not render UserMenu', async () => {
       render(await Header())
-      expect(screen.queryByRole('button', { name: 'ログアウト' })).not.toBeInTheDocument()
+      expect(screen.queryByTestId('user-menu')).not.toBeInTheDocument()
     })
   })
 
@@ -68,10 +72,9 @@ describe('Header', () => {
       })
     })
 
-    it('should render logout button', async () => {
+    it('should render UserMenu', async () => {
       render(await Header())
-      const button = screen.getByRole('button', { name: 'ログアウト' })
-      expect(button).toBeInTheDocument()
+      expect(screen.getByTestId('user-menu')).toBeInTheDocument()
     })
 
     it('should not render signup link', async () => {
@@ -84,28 +87,21 @@ describe('Header', () => {
       expect(screen.queryByRole('link', { name: 'ログイン' })).not.toBeInTheDocument()
     })
 
-    it('should not render email when user email is not available', async () => {
+    it('should display user name when available', async () => {
+      render(await Header())
+      expect(screen.getByTestId('user-display-name')).toHaveTextContent('Test User')
+    })
+
+    it('should display email when name is not available', async () => {
       mockAuth.mockResolvedValue({
         user: {
           id: 'user-1',
-          name: 'Test User',
+          email: 'test@example.com',
+          name: null,
         },
       })
       render(await Header())
-      const emailElements = document.querySelectorAll('.text-muted-foreground')
-      expect(emailElements.length).toBe(0)
-    })
-
-    it('should display user email address', async () => {
-      render(await Header())
-      const emailElement = screen.getByText('test@example.com')
-      expect(emailElement).toBeInTheDocument()
-    })
-
-    it('should hide email on mobile with hidden sm:block classes', async () => {
-      render(await Header())
-      const emailElement = screen.getByText('test@example.com')
-      expect(emailElement).toHaveClass('hidden', 'sm:block')
+      expect(screen.getByTestId('user-display-name')).toHaveTextContent('test@example.com')
     })
 
     it('should render ToDo一覧 link', async () => {

--- a/__tests__/components/UserMenu.test.tsx
+++ b/__tests__/components/UserMenu.test.tsx
@@ -1,6 +1,13 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { UserMenu } from '@/components/UserMenu'
 
+// Mock next-auth/react
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({
+    data: null, // セッションなし（propsの値を使用）
+  }),
+}))
+
 // Mock the ProfileDialog
 jest.mock('@/components/profile/ProfileDialog', () => ({
   ProfileDialog: ({ open }: { open: boolean }) => (

--- a/__tests__/components/UserMenu.test.tsx
+++ b/__tests__/components/UserMenu.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { UserMenu } from '@/components/UserMenu'
+
+// Mock the ProfileDialog
+jest.mock('@/components/profile/ProfileDialog', () => ({
+  ProfileDialog: ({ open }: { open: boolean }) => (
+    open ? <div data-testid="profile-dialog">プロフィール編集</div> : null
+  ),
+}))
+
+// Mock the logout action
+const mockLogout = jest.fn()
+jest.mock('@/actions/auth', () => ({
+  logout: () => mockLogout(),
+}))
+
+// Mock the DropdownMenu components
+jest.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children, asChild }: { children: React.ReactNode; asChild?: boolean }) => (
+    asChild ? <>{children}</> : <button>{children}</button>
+  ),
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div data-testid="dropdown-content">{children}</div>,
+  DropdownMenuItem: ({ children, onClick, asChild }: { children: React.ReactNode; onClick?: () => void; asChild?: boolean }) => {
+    if (asChild) {
+      return <div role="menuitem">{children}</div>
+    }
+    return (
+      <button role="menuitem" onClick={onClick}>
+        {children}
+      </button>
+    )
+  },
+  DropdownMenuSeparator: () => <hr />,
+}))
+
+describe('UserMenu', () => {
+  const defaultProps = {
+    name: 'テストユーザー',
+    email: 'test@example.com',
+  }
+
+  beforeEach(() => {
+    mockLogout.mockReset()
+  })
+
+  it('nameがある場合、nameが表示される', () => {
+    render(<UserMenu {...defaultProps} />)
+
+    expect(screen.getByText('テストユーザー')).toBeInTheDocument()
+  })
+
+  it('nameがnullの場合、emailが表示される', () => {
+    render(<UserMenu {...defaultProps} name={null} />)
+
+    expect(screen.getByText('test@example.com')).toBeInTheDocument()
+  })
+
+  it('nameが空文字の場合、emailが表示される', () => {
+    render(<UserMenu {...defaultProps} name="" />)
+
+    expect(screen.getByText('test@example.com')).toBeInTheDocument()
+  })
+
+  it('ドロップダウンメニューにプロフィール編集とログアウトが表示される', () => {
+    render(<UserMenu {...defaultProps} />)
+
+    expect(screen.getByRole('menuitem', { name: /プロフィール編集/i })).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: /ログアウト/i })).toBeInTheDocument()
+  })
+
+  it('プロフィール編集をクリックするとダイアログが開く', () => {
+    render(<UserMenu {...defaultProps} />)
+
+    const profileMenuItem = screen.getByRole('menuitem', { name: /プロフィール編集/i })
+    fireEvent.click(profileMenuItem)
+
+    expect(screen.getByTestId('profile-dialog')).toBeInTheDocument()
+  })
+
+  it('ログアウトボタンをクリックするとlogout actionが呼ばれる', () => {
+    render(<UserMenu {...defaultProps} />)
+
+    const logoutButton = screen.getByRole('button', { name: /ログアウト/i })
+    fireEvent.click(logoutButton)
+
+    expect(mockLogout).toHaveBeenCalled()
+  })
+})

--- a/__tests__/components/profile/BasicInfoForm.test.tsx
+++ b/__tests__/components/profile/BasicInfoForm.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { BasicInfoForm } from '@/components/profile/BasicInfoForm'
+
+// Mock the updateProfile action
+const mockUpdateProfile = jest.fn()
+jest.mock('@/actions/profile', () => ({
+  updateProfile: (...args: unknown[]) => mockUpdateProfile(...args),
+}))
+
+describe('BasicInfoForm', () => {
+  const defaultProps = {
+    initialName: 'テストユーザー',
+    initialEmail: 'test@example.com',
+    onSuccess: jest.fn(),
+  }
+
+  beforeEach(() => {
+    mockUpdateProfile.mockReset()
+    defaultProps.onSuccess.mockReset()
+  })
+
+  it('フォームフィールドが正しくレンダリングされる', () => {
+    render(<BasicInfoForm {...defaultProps} />)
+
+    expect(screen.getByLabelText('ユーザーネーム')).toBeInTheDocument()
+    expect(screen.getByLabelText('メールアドレス')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '保存' })).toBeInTheDocument()
+  })
+
+  it('初期値が正しく設定される', () => {
+    render(<BasicInfoForm {...defaultProps} />)
+
+    expect(screen.getByLabelText('ユーザーネーム')).toHaveValue('テストユーザー')
+    expect(screen.getByLabelText('メールアドレス')).toHaveValue('test@example.com')
+  })
+
+  it('ユーザーネームが空でも保存できる', async () => {
+    mockUpdateProfile.mockResolvedValue({ success: true })
+    render(<BasicInfoForm {...defaultProps} />)
+
+    const nameInput = screen.getByLabelText('ユーザーネーム')
+    fireEvent.change(nameInput, { target: { value: '' } })
+
+    const submitButton = screen.getByRole('button', { name: '保存' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockUpdateProfile).toHaveBeenCalledWith({
+        name: '',
+        email: 'test@example.com',
+      })
+    })
+  })
+
+  it('メールアドレスが空の場合バリデーションエラーが表示される', async () => {
+    render(<BasicInfoForm {...defaultProps} />)
+
+    const emailInput = screen.getByLabelText('メールアドレス')
+    fireEvent.change(emailInput, { target: { value: '' } })
+
+    const submitButton = screen.getByRole('button', { name: '保存' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('有効なメールアドレスを入力してください')).toBeInTheDocument()
+    })
+    expect(mockUpdateProfile).not.toHaveBeenCalled()
+  })
+
+  it('無効なメールアドレスの場合バリデーションエラーが表示される', async () => {
+    render(<BasicInfoForm {...defaultProps} />)
+
+    const emailInput = screen.getByLabelText('メールアドレス')
+    fireEvent.change(emailInput, { target: { value: 'invalid-email' } })
+
+    const submitButton = screen.getByRole('button', { name: '保存' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('有効なメールアドレスを入力してください')).toBeInTheDocument()
+    })
+    expect(mockUpdateProfile).not.toHaveBeenCalled()
+  })
+
+  it('有効なデータで保存が成功する', async () => {
+    mockUpdateProfile.mockResolvedValue({ success: true })
+    render(<BasicInfoForm {...defaultProps} />)
+
+    const nameInput = screen.getByLabelText('ユーザーネーム')
+    fireEvent.change(nameInput, { target: { value: '新しい名前' } })
+
+    const emailInput = screen.getByLabelText('メールアドレス')
+    fireEvent.change(emailInput, { target: { value: 'new@example.com' } })
+
+    const submitButton = screen.getByRole('button', { name: '保存' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockUpdateProfile).toHaveBeenCalledWith({
+        name: '新しい名前',
+        email: 'new@example.com',
+      })
+    })
+
+    await waitFor(() => {
+      expect(defaultProps.onSuccess).toHaveBeenCalled()
+    })
+  })
+
+  it('サーバーエラーが表示される', async () => {
+    mockUpdateProfile.mockResolvedValue({
+      success: false,
+      error: 'このメールアドレスは既に使用されています',
+    })
+    render(<BasicInfoForm {...defaultProps} />)
+
+    const emailInput = screen.getByLabelText('メールアドレス')
+    fireEvent.change(emailInput, { target: { value: 'existing@example.com' } })
+
+    const submitButton = screen.getByRole('button', { name: '保存' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('このメールアドレスは既に使用されています')).toBeInTheDocument()
+    })
+    expect(defaultProps.onSuccess).not.toHaveBeenCalled()
+  })
+
+  it('初期ユーザーネームがnullの場合、空文字で表示される', () => {
+    render(<BasicInfoForm {...defaultProps} initialName={null} />)
+
+    expect(screen.getByLabelText('ユーザーネーム')).toHaveValue('')
+  })
+})

--- a/__tests__/components/profile/PasswordForm.test.tsx
+++ b/__tests__/components/profile/PasswordForm.test.tsx
@@ -1,0 +1,184 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { PasswordForm } from '@/components/profile/PasswordForm'
+
+// Mock the changePassword action
+const mockChangePassword = jest.fn()
+jest.mock('@/actions/profile', () => ({
+  changePassword: (...args: unknown[]) => mockChangePassword(...args),
+}))
+
+describe('PasswordForm', () => {
+  const defaultProps = {
+    onSuccess: jest.fn(),
+  }
+
+  beforeEach(() => {
+    mockChangePassword.mockReset()
+    defaultProps.onSuccess.mockReset()
+  })
+
+  it('フォームフィールドが正しくレンダリングされる', () => {
+    render(<PasswordForm {...defaultProps} />)
+
+    expect(screen.getByLabelText('現在のパスワード')).toBeInTheDocument()
+    expect(screen.getByLabelText('新しいパスワード')).toBeInTheDocument()
+    expect(screen.getByLabelText('新しいパスワード（確認）')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'パスワードを変更' })).toBeInTheDocument()
+  })
+
+  it('現在のパスワードが空の場合バリデーションエラーが表示される', async () => {
+    render(<PasswordForm {...defaultProps} />)
+
+    const newPasswordInput = screen.getByLabelText('新しいパスワード')
+    fireEvent.change(newPasswordInput, { target: { value: 'newpass123' } })
+
+    const confirmPasswordInput = screen.getByLabelText('新しいパスワード（確認）')
+    fireEvent.change(confirmPasswordInput, { target: { value: 'newpass123' } })
+
+    const submitButton = screen.getByRole('button', { name: 'パスワードを変更' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('現在のパスワードを入力してください')).toBeInTheDocument()
+    })
+    expect(mockChangePassword).not.toHaveBeenCalled()
+  })
+
+  it('新しいパスワードが8文字未満の場合バリデーションエラーが表示される', async () => {
+    render(<PasswordForm {...defaultProps} />)
+
+    const currentPasswordInput = screen.getByLabelText('現在のパスワード')
+    fireEvent.change(currentPasswordInput, { target: { value: 'current123' } })
+
+    const newPasswordInput = screen.getByLabelText('新しいパスワード')
+    fireEvent.change(newPasswordInput, { target: { value: 'short1' } })
+
+    const confirmPasswordInput = screen.getByLabelText('新しいパスワード（確認）')
+    fireEvent.change(confirmPasswordInput, { target: { value: 'short1' } })
+
+    const submitButton = screen.getByRole('button', { name: 'パスワードを変更' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('パスワードは8文字以上で入力してください')).toBeInTheDocument()
+    })
+    expect(mockChangePassword).not.toHaveBeenCalled()
+  })
+
+  it('新しいパスワードに英字が含まれない場合バリデーションエラーが表示される', async () => {
+    render(<PasswordForm {...defaultProps} />)
+
+    const currentPasswordInput = screen.getByLabelText('現在のパスワード')
+    fireEvent.change(currentPasswordInput, { target: { value: 'current123' } })
+
+    const newPasswordInput = screen.getByLabelText('新しいパスワード')
+    fireEvent.change(newPasswordInput, { target: { value: '12345678' } })
+
+    const confirmPasswordInput = screen.getByLabelText('新しいパスワード（確認）')
+    fireEvent.change(confirmPasswordInput, { target: { value: '12345678' } })
+
+    const submitButton = screen.getByRole('button', { name: 'パスワードを変更' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('パスワードには英字と数字を含めてください')).toBeInTheDocument()
+    })
+    expect(mockChangePassword).not.toHaveBeenCalled()
+  })
+
+  it('新しいパスワードに数字が含まれない場合バリデーションエラーが表示される', async () => {
+    render(<PasswordForm {...defaultProps} />)
+
+    const currentPasswordInput = screen.getByLabelText('現在のパスワード')
+    fireEvent.change(currentPasswordInput, { target: { value: 'current123' } })
+
+    const newPasswordInput = screen.getByLabelText('新しいパスワード')
+    fireEvent.change(newPasswordInput, { target: { value: 'abcdefgh' } })
+
+    const confirmPasswordInput = screen.getByLabelText('新しいパスワード（確認）')
+    fireEvent.change(confirmPasswordInput, { target: { value: 'abcdefgh' } })
+
+    const submitButton = screen.getByRole('button', { name: 'パスワードを変更' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('パスワードには英字と数字を含めてください')).toBeInTheDocument()
+    })
+    expect(mockChangePassword).not.toHaveBeenCalled()
+  })
+
+  it('新しいパスワードと確認用が一致しない場合バリデーションエラーが表示される', async () => {
+    render(<PasswordForm {...defaultProps} />)
+
+    const currentPasswordInput = screen.getByLabelText('現在のパスワード')
+    fireEvent.change(currentPasswordInput, { target: { value: 'current123' } })
+
+    const newPasswordInput = screen.getByLabelText('新しいパスワード')
+    fireEvent.change(newPasswordInput, { target: { value: 'newpass123' } })
+
+    const confirmPasswordInput = screen.getByLabelText('新しいパスワード（確認）')
+    fireEvent.change(confirmPasswordInput, { target: { value: 'different123' } })
+
+    const submitButton = screen.getByRole('button', { name: 'パスワードを変更' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('新しいパスワードが一致しません')).toBeInTheDocument()
+    })
+    expect(mockChangePassword).not.toHaveBeenCalled()
+  })
+
+  it('有効なデータでパスワード変更が成功する', async () => {
+    mockChangePassword.mockResolvedValue({ success: true })
+    render(<PasswordForm {...defaultProps} />)
+
+    const currentPasswordInput = screen.getByLabelText('現在のパスワード')
+    fireEvent.change(currentPasswordInput, { target: { value: 'current123' } })
+
+    const newPasswordInput = screen.getByLabelText('新しいパスワード')
+    fireEvent.change(newPasswordInput, { target: { value: 'newpass123' } })
+
+    const confirmPasswordInput = screen.getByLabelText('新しいパスワード（確認）')
+    fireEvent.change(confirmPasswordInput, { target: { value: 'newpass123' } })
+
+    const submitButton = screen.getByRole('button', { name: 'パスワードを変更' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockChangePassword).toHaveBeenCalledWith({
+        currentPassword: 'current123',
+        newPassword: 'newpass123',
+        confirmNewPassword: 'newpass123',
+      })
+    })
+
+    await waitFor(() => {
+      expect(defaultProps.onSuccess).toHaveBeenCalled()
+    })
+  })
+
+  it('サーバーエラーが表示される', async () => {
+    mockChangePassword.mockResolvedValue({
+      success: false,
+      error: '現在のパスワードが正しくありません',
+    })
+    render(<PasswordForm {...defaultProps} />)
+
+    const currentPasswordInput = screen.getByLabelText('現在のパスワード')
+    fireEvent.change(currentPasswordInput, { target: { value: 'wrongpass' } })
+
+    const newPasswordInput = screen.getByLabelText('新しいパスワード')
+    fireEvent.change(newPasswordInput, { target: { value: 'newpass123' } })
+
+    const confirmPasswordInput = screen.getByLabelText('新しいパスワード（確認）')
+    fireEvent.change(confirmPasswordInput, { target: { value: 'newpass123' } })
+
+    const submitButton = screen.getByRole('button', { name: 'パスワードを変更' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('現在のパスワードが正しくありません')).toBeInTheDocument()
+    })
+    expect(defaultProps.onSuccess).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/components/profile/ProfileDialog.test.tsx
+++ b/__tests__/components/profile/ProfileDialog.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ProfileDialog } from '@/components/profile/ProfileDialog'
+
+// Mock the form components
+jest.mock('@/components/profile/BasicInfoForm', () => ({
+  BasicInfoForm: ({ onSuccess }: { onSuccess: () => void }) => (
+    <div data-testid="basic-info-form">
+      <button onClick={onSuccess}>保存</button>
+    </div>
+  ),
+}))
+
+jest.mock('@/components/profile/PasswordForm', () => ({
+  PasswordForm: ({ onSuccess }: { onSuccess: () => void }) => (
+    <div data-testid="password-form">
+      <button onClick={onSuccess}>パスワードを変更</button>
+    </div>
+  ),
+}))
+
+describe('ProfileDialog', () => {
+  const defaultProps = {
+    open: true,
+    onOpenChange: jest.fn(),
+    initialName: 'テストユーザー',
+    initialEmail: 'test@example.com',
+  }
+
+  beforeEach(() => {
+    defaultProps.onOpenChange.mockReset()
+  })
+
+  it('ダイアログが開いている時、タイトルと2つのセクションが表示される', () => {
+    render(<ProfileDialog {...defaultProps} />)
+
+    expect(screen.getByText('プロフィール編集')).toBeInTheDocument()
+    expect(screen.getByText('基本情報')).toBeInTheDocument()
+    expect(screen.getByText('パスワード変更')).toBeInTheDocument()
+  })
+
+  it('基本情報セクションにBasicInfoFormが表示される', () => {
+    render(<ProfileDialog {...defaultProps} />)
+
+    expect(screen.getByTestId('basic-info-form')).toBeInTheDocument()
+  })
+
+  it('パスワード変更セクションにPasswordFormが表示される', () => {
+    render(<ProfileDialog {...defaultProps} />)
+
+    expect(screen.getByTestId('password-form')).toBeInTheDocument()
+  })
+
+  it('ダイアログが閉じている時、コンテンツは表示されない', () => {
+    render(<ProfileDialog {...defaultProps} open={false} />)
+
+    expect(screen.queryByText('プロフィール編集')).not.toBeInTheDocument()
+  })
+
+  it('閉じるボタンをクリックするとonOpenChangeが呼ばれる', () => {
+    render(<ProfileDialog {...defaultProps} />)
+
+    // Dialogの閉じるボタン（×）をクリック
+    const closeButton = screen.getByRole('button', { name: /close/i })
+    fireEvent.click(closeButton)
+
+    expect(defaultProps.onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/__tests__/components/profile/ProfileDialog.test.tsx
+++ b/__tests__/components/profile/ProfileDialog.test.tsx
@@ -65,4 +65,22 @@ describe('ProfileDialog', () => {
 
     expect(defaultProps.onOpenChange).toHaveBeenCalledWith(false)
   })
+
+  it('基本情報の保存成功時にダイアログが閉じる', () => {
+    render(<ProfileDialog {...defaultProps} />)
+
+    const saveButton = screen.getByRole('button', { name: '保存' })
+    fireEvent.click(saveButton)
+
+    expect(defaultProps.onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('パスワード変更成功時にダイアログが閉じる', () => {
+    render(<ProfileDialog {...defaultProps} />)
+
+    const changePasswordButton = screen.getByRole('button', { name: 'パスワードを変更' })
+    fireEvent.click(changePasswordButton)
+
+    expect(defaultProps.onOpenChange).toHaveBeenCalledWith(false)
+  })
 })

--- a/__tests__/lib/validations/auth.test.ts
+++ b/__tests__/lib/validations/auth.test.ts
@@ -27,13 +27,39 @@ describe('signupSchema', () => {
   it('should reject password shorter than 8 characters', () => {
     const invalidData = {
       email: 'test@example.com',
-      password: 'short',
-      confirmPassword: 'short',
+      password: 'short1',
+      confirmPassword: 'short1',
     }
     const result = signupSchema.safeParse(invalidData)
     expect(result.success).toBe(false)
     if (!result.success) {
-      expect(result.error.issues[0].path).toContain('password')
+      expect(result.error.issues[0].message).toBe('パスワードは8文字以上で入力してください')
+    }
+  })
+
+  it('should reject password without letters', () => {
+    const invalidData = {
+      email: 'test@example.com',
+      password: '12345678',
+      confirmPassword: '12345678',
+    }
+    const result = signupSchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe('パスワードには英字と数字を含めてください')
+    }
+  })
+
+  it('should reject password without numbers', () => {
+    const invalidData = {
+      email: 'test@example.com',
+      password: 'abcdefgh',
+      confirmPassword: 'abcdefgh',
+    }
+    const result = signupSchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe('パスワードには英字と数字を含めてください')
     }
   })
 

--- a/__tests__/lib/validations/profile.test.ts
+++ b/__tests__/lib/validations/profile.test.ts
@@ -1,6 +1,7 @@
 import {
   updateProfileSchema,
   changePasswordSchema,
+  normalizeProfileInput,
   UpdateProfileInput,
   ChangePasswordInput,
 } from '@/lib/validations/profile'
@@ -67,6 +68,61 @@ describe('updateProfileSchema', () => {
         expect(result.error.issues[0].message).toBe('有効なメールアドレスを入力してください')
       }
     })
+  })
+})
+
+describe('normalizeProfileInput', () => {
+  it('emailがtrimされて小文字に変換される', () => {
+    const input: UpdateProfileInput = {
+      name: 'テストユーザー',
+      email: '  TEST@EXAMPLE.COM  ',
+    }
+    const result = normalizeProfileInput(input)
+    expect(result.email).toBe('test@example.com')
+  })
+
+  it('nameがtrimされる', () => {
+    const input: UpdateProfileInput = {
+      name: '  テストユーザー  ',
+      email: 'test@example.com',
+    }
+    const result = normalizeProfileInput(input)
+    expect(result.name).toBe('テストユーザー')
+  })
+
+  it('nameが空白のみの場合、nullに変換される', () => {
+    const input: UpdateProfileInput = {
+      name: '   ',
+      email: 'test@example.com',
+    }
+    const result = normalizeProfileInput(input)
+    expect(result.name).toBeNull()
+  })
+
+  it('nameが空文字の場合、nullに変換される', () => {
+    const input: UpdateProfileInput = {
+      name: '',
+      email: 'test@example.com',
+    }
+    const result = normalizeProfileInput(input)
+    expect(result.name).toBeNull()
+  })
+
+  it('nameがnullの場合、nullのまま', () => {
+    const input: UpdateProfileInput = {
+      name: null,
+      email: 'test@example.com',
+    }
+    const result = normalizeProfileInput(input)
+    expect(result.name).toBeNull()
+  })
+
+  it('nameがundefinedの場合、nullに変換される', () => {
+    const input: UpdateProfileInput = {
+      email: 'test@example.com',
+    }
+    const result = normalizeProfileInput(input)
+    expect(result.name).toBeNull()
   })
 })
 

--- a/__tests__/lib/validations/profile.test.ts
+++ b/__tests__/lib/validations/profile.test.ts
@@ -42,6 +42,18 @@ describe('updateProfileSchema', () => {
       const result = updateProfileSchema.safeParse(input)
       expect(result.success).toBe(true)
     })
+
+    it('emailの前後に空白がある場合、trimされてバリデーションが成功する', () => {
+      const input = {
+        name: 'テストユーザー',
+        email: '  test@example.com  ',
+      }
+      const result = updateProfileSchema.safeParse(input)
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.email).toBe('test@example.com')
+      }
+    })
   })
 
   describe('異常系', () => {
@@ -72,10 +84,10 @@ describe('updateProfileSchema', () => {
 })
 
 describe('normalizeProfileInput', () => {
-  it('emailがtrimされて小文字に変換される', () => {
+  it('emailが小文字に変換される（trimはスキーマで実行済み）', () => {
     const input: UpdateProfileInput = {
       name: 'テストユーザー',
-      email: '  TEST@EXAMPLE.COM  ',
+      email: 'TEST@EXAMPLE.COM',
     }
     const result = normalizeProfileInput(input)
     expect(result.email).toBe('test@example.com')
@@ -117,12 +129,12 @@ describe('normalizeProfileInput', () => {
     expect(result.name).toBeNull()
   })
 
-  it('nameがundefinedの場合、nullに変換される', () => {
+  it('nameがundefinedの場合、undefinedのまま（更新対象から外す）', () => {
     const input: UpdateProfileInput = {
       email: 'test@example.com',
     }
     const result = normalizeProfileInput(input)
-    expect(result.name).toBeNull()
+    expect(result.name).toBeUndefined()
   })
 })
 

--- a/__tests__/lib/validations/profile.test.ts
+++ b/__tests__/lib/validations/profile.test.ts
@@ -1,0 +1,152 @@
+import {
+  updateProfileSchema,
+  changePasswordSchema,
+  UpdateProfileInput,
+  ChangePasswordInput,
+} from '@/lib/validations/profile'
+
+describe('updateProfileSchema', () => {
+  describe('正常系', () => {
+    it('nameとemailが有効な場合、バリデーションが成功する', () => {
+      const input: UpdateProfileInput = {
+        name: 'テストユーザー',
+        email: 'test@example.com',
+      }
+      const result = updateProfileSchema.safeParse(input)
+      expect(result.success).toBe(true)
+    })
+
+    it('nameが空文字の場合でもバリデーションが成功する', () => {
+      const input: UpdateProfileInput = {
+        name: '',
+        email: 'test@example.com',
+      }
+      const result = updateProfileSchema.safeParse(input)
+      expect(result.success).toBe(true)
+    })
+
+    it('nameがnullの場合でもバリデーションが成功する', () => {
+      const input = {
+        name: null,
+        email: 'test@example.com',
+      }
+      const result = updateProfileSchema.safeParse(input)
+      expect(result.success).toBe(true)
+    })
+
+    it('nameが未定義の場合でもバリデーションが成功する', () => {
+      const input = {
+        email: 'test@example.com',
+      }
+      const result = updateProfileSchema.safeParse(input)
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('異常系', () => {
+    it('emailが空の場合、バリデーションエラーになる', () => {
+      const input = {
+        name: 'テストユーザー',
+        email: '',
+      }
+      const result = updateProfileSchema.safeParse(input)
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('有効なメールアドレスを入力してください')
+      }
+    })
+
+    it('emailがメール形式でない場合、バリデーションエラーになる', () => {
+      const input = {
+        name: 'テストユーザー',
+        email: 'invalid-email',
+      }
+      const result = updateProfileSchema.safeParse(input)
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('有効なメールアドレスを入力してください')
+      }
+    })
+  })
+})
+
+describe('changePasswordSchema', () => {
+  describe('正常系', () => {
+    it('全てのフィールドが有効な場合、バリデーションが成功する', () => {
+      const input: ChangePasswordInput = {
+        currentPassword: 'currentPass123',
+        newPassword: 'newPass123',
+        confirmNewPassword: 'newPass123',
+      }
+      const result = changePasswordSchema.safeParse(input)
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('異常系', () => {
+    it('currentPasswordが空の場合、バリデーションエラーになる', () => {
+      const input = {
+        currentPassword: '',
+        newPassword: 'newPass123',
+        confirmNewPassword: 'newPass123',
+      }
+      const result = changePasswordSchema.safeParse(input)
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('現在のパスワードを入力してください')
+      }
+    })
+
+    it('newPasswordが8文字未満の場合、バリデーションエラーになる', () => {
+      const input = {
+        currentPassword: 'currentPass123',
+        newPassword: 'pass1',
+        confirmNewPassword: 'pass1',
+      }
+      const result = changePasswordSchema.safeParse(input)
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('パスワードは8文字以上で入力してください')
+      }
+    })
+
+    it('newPasswordに英字が含まれない場合、バリデーションエラーになる', () => {
+      const input = {
+        currentPassword: 'currentPass123',
+        newPassword: '12345678',
+        confirmNewPassword: '12345678',
+      }
+      const result = changePasswordSchema.safeParse(input)
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('パスワードには英字と数字を含めてください')
+      }
+    })
+
+    it('newPasswordに数字が含まれない場合、バリデーションエラーになる', () => {
+      const input = {
+        currentPassword: 'currentPass123',
+        newPassword: 'abcdefgh',
+        confirmNewPassword: 'abcdefgh',
+      }
+      const result = changePasswordSchema.safeParse(input)
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('パスワードには英字と数字を含めてください')
+      }
+    })
+
+    it('confirmNewPasswordが一致しない場合、バリデーションエラーになる', () => {
+      const input = {
+        currentPassword: 'currentPass123',
+        newPassword: 'newPass123',
+        confirmNewPassword: 'differentPass123',
+      }
+      const result = changePasswordSchema.safeParse(input)
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('新しいパスワードが一致しません')
+      }
+    })
+  })
+})

--- a/actions/auth.ts
+++ b/actions/auth.ts
@@ -17,7 +17,9 @@ export async function signup(data: SignupInput): Promise<AuthResult> {
     return { success: false, error: parsed.error.issues[0].message }
   }
 
-  const { email, password } = parsed.data
+  const { password } = parsed.data
+  // メールアドレスを小文字に正規化（trimはスキーマで実行済み）
+  const email = parsed.data.email.toLowerCase()
 
   const existingUser = await prisma.user.findUnique({
     where: { email },
@@ -55,7 +57,9 @@ export async function login(data: LoginInput): Promise<AuthResult> {
     return { success: false, error: parsed.error.issues[0].message }
   }
 
-  const { email, password } = parsed.data
+  const { password } = parsed.data
+  // メールアドレスを小文字に正規化（trimはスキーマで実行済み）
+  const email = parsed.data.email.toLowerCase()
 
   try {
     await signIn('credentials', {

--- a/actions/profile.ts
+++ b/actions/profile.ts
@@ -6,9 +6,20 @@ import { auth } from '@/lib/auth'
 import {
   updateProfileSchema,
   changePasswordSchema,
+  normalizeProfileInput,
   type UpdateProfileInput,
   type ChangePasswordInput,
 } from '@/lib/validations/profile'
+
+// Prisma P2002 error check helper
+function isPrismaUniqueConstraintError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code: string }).code === 'P2002'
+  )
+}
 
 export type ProfileResult = {
   success: boolean
@@ -26,7 +37,8 @@ export async function updateProfile(data: UpdateProfileInput): Promise<ProfileRe
     return { success: false, error: '認証が必要です' }
   }
 
-  const { name, email } = parsed.data
+  // 正規化（trim, 空文字→null, email小文字化）
+  const { name, email } = normalizeProfileInput(parsed.data)
 
   // 他のユーザーがこのメールアドレスを使用していないかチェック
   const existingUser = await prisma.user.findUnique({
@@ -37,10 +49,17 @@ export async function updateProfile(data: UpdateProfileInput): Promise<ProfileRe
     return { success: false, error: 'このメールアドレスは既に使用されています' }
   }
 
-  await prisma.user.update({
-    where: { id: session.user.id },
-    data: { name: name ?? null, email },
-  })
+  try {
+    await prisma.user.update({
+      where: { id: session.user.id },
+      data: { name, email },
+    })
+  } catch (error) {
+    if (isPrismaUniqueConstraintError(error)) {
+      return { success: false, error: 'このメールアドレスは既に使用されています' }
+    }
+    throw error
+  }
 
   return { success: true }
 }

--- a/actions/profile.ts
+++ b/actions/profile.ts
@@ -63,10 +63,7 @@ export async function updateProfile(data: UpdateProfileInput): Promise<ProfileRe
   }
 
   // name未指定時は更新対象から外す（既存値を保持）
-  const updateData: { email: string; name?: string | null } = { email }
-  if (name !== undefined) {
-    updateData.name = name
-  }
+  const updateData = name === undefined ? { email } : { email, name }
 
   try {
     await prisma.user.update({

--- a/actions/profile.ts
+++ b/actions/profile.ts
@@ -23,14 +23,23 @@ function getUniqueConstraintField(error: unknown): 'email' | 'unknown' | null {
     return null
   }
 
-  // meta.targetでフィールドを確認
+  // meta.targetでフィールドを確認（配列または文字列の場合がある）
   if ('meta' in error && typeof (error as { meta: unknown }).meta === 'object') {
     const meta = (error as { meta: { target?: unknown } }).meta
-    if (Array.isArray(meta?.target) && meta.target.includes('email')) {
-      return 'email'
+    const target = meta?.target
+
+    // targetが配列の場合
+    if (Array.isArray(target)) {
+      return target.includes('email') ? 'email' : 'unknown'
     }
-    // targetがあるがemailではない場合
-    if (meta?.target) {
+
+    // targetが文字列の場合
+    if (typeof target === 'string') {
+      return target === 'email' || target.includes('email') ? 'email' : 'unknown'
+    }
+
+    // targetが存在するが配列でも文字列でもない場合
+    if (target) {
       return 'unknown'
     }
   }

--- a/actions/profile.ts
+++ b/actions/profile.ts
@@ -1,0 +1,82 @@
+'use server'
+
+import bcrypt from 'bcryptjs'
+import { prisma } from '@/lib/prisma'
+import { auth } from '@/lib/auth'
+import {
+  updateProfileSchema,
+  changePasswordSchema,
+  type UpdateProfileInput,
+  type ChangePasswordInput,
+} from '@/lib/validations/profile'
+
+export type ProfileResult = {
+  success: boolean
+  error?: string
+}
+
+export async function updateProfile(data: UpdateProfileInput): Promise<ProfileResult> {
+  const parsed = updateProfileSchema.safeParse(data)
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0].message }
+  }
+
+  const session = await auth()
+  if (!session?.user?.id) {
+    return { success: false, error: '認証が必要です' }
+  }
+
+  const { name, email } = parsed.data
+
+  // 他のユーザーがこのメールアドレスを使用していないかチェック
+  const existingUser = await prisma.user.findUnique({
+    where: { email },
+  })
+
+  if (existingUser && existingUser.id !== session.user.id) {
+    return { success: false, error: 'このメールアドレスは既に使用されています' }
+  }
+
+  await prisma.user.update({
+    where: { id: session.user.id },
+    data: { name: name ?? null, email },
+  })
+
+  return { success: true }
+}
+
+export async function changePassword(data: ChangePasswordInput): Promise<ProfileResult> {
+  const parsed = changePasswordSchema.safeParse(data)
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues[0].message }
+  }
+
+  const session = await auth()
+  if (!session?.user?.id) {
+    return { success: false, error: '認証が必要です' }
+  }
+
+  const { currentPassword, newPassword } = parsed.data
+
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+  })
+
+  if (!user?.password) {
+    return { success: false, error: 'パスワードが設定されていません' }
+  }
+
+  const isValidPassword = await bcrypt.compare(currentPassword, user.password)
+  if (!isValidPassword) {
+    return { success: false, error: '現在のパスワードが正しくありません' }
+  }
+
+  const hashedPassword = await bcrypt.hash(newPassword, 12)
+
+  await prisma.user.update({
+    where: { id: session.user.id },
+    data: { password: hashedPassword },
+  })
+
+  return { success: true }
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 import { CheckSquare } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { auth } from '@/lib/auth'
-import { logout } from '@/actions/auth'
+import { UserMenu } from '@/components/UserMenu'
 
 export async function Header() {
   const session = await auth()
@@ -15,21 +15,15 @@ export async function Header() {
           <span className="text-xl font-bold">ToDoアプリ</span>
         </Link>
         <div className="flex items-center gap-2">
-          {session ? (
+          {session?.user?.email ? (
             <>
-              {session.user?.email && (
-                <span className="hidden text-sm text-muted-foreground sm:block">
-                  {session.user.email}
-                </span>
-              )}
               <Button variant="ghost" asChild>
                 <Link href="/todos">ToDo一覧</Link>
               </Button>
-              <form action={logout}>
-                <Button type="submit" variant="outline">
-                  ログアウト
-                </Button>
-              </form>
+              <UserMenu
+                name={session.user.name ?? null}
+                email={session.user.email}
+              />
             </>
           ) : (
             <>

--- a/components/UserMenu.tsx
+++ b/components/UserMenu.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { useSession } from 'next-auth/react'
 import { User, LogOut } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
@@ -18,9 +19,13 @@ interface UserMenuProps {
   email: string
 }
 
-export function UserMenu({ name, email }: UserMenuProps) {
+export function UserMenu({ name: initialName, email: initialEmail }: UserMenuProps) {
+  const { data: session } = useSession()
   const [isProfileDialogOpen, setIsProfileDialogOpen] = useState(false)
 
+  // セッションからリアルタイムの値を取得（なければ初期値を使用）
+  const name = session?.user?.name ?? initialName
+  const email = session?.user?.email ?? initialEmail
   const displayName = name && name.trim() !== '' ? name : email
 
   return (

--- a/components/UserMenu.tsx
+++ b/components/UserMenu.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useState } from 'react'
+import { User, LogOut } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { ProfileDialog } from '@/components/profile/ProfileDialog'
+import { logout } from '@/actions/auth'
+
+interface UserMenuProps {
+  name: string | null
+  email: string
+}
+
+export function UserMenu({ name, email }: UserMenuProps) {
+  const [isProfileDialogOpen, setIsProfileDialogOpen] = useState(false)
+
+  const displayName = name && name.trim() !== '' ? name : email
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" className="gap-2">
+            <User className="size-4" aria-hidden="true" />
+            <span className="hidden sm:inline">{displayName}</span>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={() => setIsProfileDialogOpen(true)}>
+            <User className="mr-2 size-4" />
+            プロフィール編集
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <form action={logout}>
+            <DropdownMenuItem asChild>
+              <button type="submit" className="w-full">
+                <LogOut className="mr-2 size-4" />
+                ログアウト
+              </button>
+            </DropdownMenuItem>
+          </form>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <ProfileDialog
+        open={isProfileDialogOpen}
+        onOpenChange={setIsProfileDialogOpen}
+        initialName={name}
+        initialEmail={email}
+      />
+    </>
+  )
+}

--- a/components/profile/BasicInfoForm.tsx
+++ b/components/profile/BasicInfoForm.tsx
@@ -41,8 +41,12 @@ export function BasicInfoForm({ initialName, initialEmail, onSuccess }: BasicInf
     if (result.success) {
       // セッションを更新して、UIに即座に反映する
       // 失敗してもプロフィール自体は保存済みなので、onSuccessは呼び出す
+      // メールはDBと同様に小文字で保存されているため、小文字で更新
       try {
-        await updateSession({ name: data.name, email: data.email })
+        await updateSession({
+          name: data.name,
+          email: data.email.trim().toLowerCase(),
+        })
       } catch {
         // セッション更新失敗はログのみ（プロフィール保存は成功している）
         console.error('セッションの更新に失敗しました')

--- a/components/profile/BasicInfoForm.tsx
+++ b/components/profile/BasicInfoForm.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { updateProfileSchema, type UpdateProfileInput } from '@/lib/validations/profile'
+import { updateProfile } from '@/actions/profile'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+
+interface BasicInfoFormProps {
+  initialName: string | null
+  initialEmail: string
+  onSuccess: () => void
+}
+
+export function BasicInfoForm({ initialName, initialEmail, onSuccess }: BasicInfoFormProps) {
+  const [serverError, setServerError] = useState<string | null>(null)
+
+  const form = useForm<UpdateProfileInput>({
+    resolver: zodResolver(updateProfileSchema),
+    defaultValues: {
+      name: initialName ?? '',
+      email: initialEmail,
+    },
+  })
+
+  const onSubmit = async (data: UpdateProfileInput) => {
+    setServerError(null)
+    const result = await updateProfile(data)
+    if (result.success) {
+      onSuccess()
+    } else if (result.error) {
+      setServerError(result.error)
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4" noValidate>
+        {serverError && (
+          <div className="p-3 text-sm text-red-500 bg-red-50 dark:bg-red-950 rounded-md">
+            {serverError}
+          </div>
+        )}
+
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>ユーザーネーム</FormLabel>
+              <FormControl>
+                <Input placeholder="ユーザーネーム（任意）" {...field} value={field.value ?? ''} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>メールアドレス</FormLabel>
+              <FormControl>
+                <Input type="email" placeholder="example@example.com" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <Button type="submit" className="w-full">
+          保存
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/components/profile/BasicInfoForm.tsx
+++ b/components/profile/BasicInfoForm.tsx
@@ -40,7 +40,13 @@ export function BasicInfoForm({ initialName, initialEmail, onSuccess }: BasicInf
     const result = await updateProfile(data)
     if (result.success) {
       // セッションを更新して、UIに即座に反映する
-      await updateSession()
+      // 失敗してもプロフィール自体は保存済みなので、onSuccessは呼び出す
+      try {
+        await updateSession({ name: data.name, email: data.email })
+      } catch {
+        // セッション更新失敗はログのみ（プロフィール保存は成功している）
+        console.error('セッションの更新に失敗しました')
+      }
       onSuccess()
     } else if (result.error) {
       setServerError(result.error)

--- a/components/profile/BasicInfoForm.tsx
+++ b/components/profile/BasicInfoForm.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { useSession } from 'next-auth/react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { updateProfileSchema, type UpdateProfileInput } from '@/lib/validations/profile'
@@ -23,6 +24,7 @@ interface BasicInfoFormProps {
 }
 
 export function BasicInfoForm({ initialName, initialEmail, onSuccess }: BasicInfoFormProps) {
+  const { update: updateSession } = useSession()
   const [serverError, setServerError] = useState<string | null>(null)
 
   const form = useForm<UpdateProfileInput>({
@@ -37,6 +39,8 @@ export function BasicInfoForm({ initialName, initialEmail, onSuccess }: BasicInf
     setServerError(null)
     const result = await updateProfile(data)
     if (result.success) {
+      // セッションを更新して、UIに即座に反映する
+      await updateSession()
       onSuccess()
     } else if (result.error) {
       setServerError(result.error)

--- a/components/profile/PasswordForm.tsx
+++ b/components/profile/PasswordForm.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { changePasswordSchema, type ChangePasswordInput } from '@/lib/validations/profile'
+import { changePassword } from '@/actions/profile'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+
+interface PasswordFormProps {
+  onSuccess: () => void
+}
+
+export function PasswordForm({ onSuccess }: PasswordFormProps) {
+  const [serverError, setServerError] = useState<string | null>(null)
+
+  const form = useForm<ChangePasswordInput>({
+    resolver: zodResolver(changePasswordSchema),
+    defaultValues: {
+      currentPassword: '',
+      newPassword: '',
+      confirmNewPassword: '',
+    },
+  })
+
+  const onSubmit = async (data: ChangePasswordInput) => {
+    setServerError(null)
+    const result = await changePassword(data)
+    if (result.success) {
+      form.reset()
+      onSuccess()
+    } else if (result.error) {
+      setServerError(result.error)
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4" noValidate>
+        {serverError && (
+          <div className="p-3 text-sm text-red-500 bg-red-50 dark:bg-red-950 rounded-md">
+            {serverError}
+          </div>
+        )}
+
+        <FormField
+          control={form.control}
+          name="currentPassword"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>現在のパスワード</FormLabel>
+              <FormControl>
+                <Input type="password" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="newPassword"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>新しいパスワード</FormLabel>
+              <FormControl>
+                <Input type="password" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="confirmNewPassword"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>新しいパスワード（確認）</FormLabel>
+              <FormControl>
+                <Input type="password" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <Button type="submit" className="w-full">
+          パスワードを変更
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/components/profile/ProfileDialog.tsx
+++ b/components/profile/ProfileDialog.tsx
@@ -24,11 +24,13 @@ export function ProfileDialog({
   initialEmail,
 }: ProfileDialogProps) {
   const handleBasicInfoSuccess = () => {
-    // 基本情報更新成功時の処理（必要に応じてトースト表示など）
+    // 基本情報更新成功時にダイアログを閉じる
+    onOpenChange(false)
   }
 
   const handlePasswordSuccess = () => {
-    // パスワード変更成功時の処理（必要に応じてトースト表示など）
+    // パスワード変更成功時にダイアログを閉じる
+    onOpenChange(false)
   }
 
   return (

--- a/components/profile/ProfileDialog.tsx
+++ b/components/profile/ProfileDialog.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { BasicInfoForm } from './BasicInfoForm'
+import { PasswordForm } from './PasswordForm'
+
+interface ProfileDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  initialName: string | null
+  initialEmail: string
+}
+
+export function ProfileDialog({
+  open,
+  onOpenChange,
+  initialName,
+  initialEmail,
+}: ProfileDialogProps) {
+  const handleBasicInfoSuccess = () => {
+    // 基本情報更新成功時の処理（必要に応じてトースト表示など）
+  }
+
+  const handlePasswordSuccess = () => {
+    // パスワード変更成功時の処理（必要に応じてトースト表示など）
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>プロフィール編集</DialogTitle>
+          <DialogDescription>
+            プロフィール情報やパスワードを変更できます
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-6">
+          <section>
+            <h3 className="text-lg font-medium mb-4">基本情報</h3>
+            <BasicInfoForm
+              initialName={initialName}
+              initialEmail={initialEmail}
+              onSuccess={handleBasicInfoSuccess}
+            />
+          </section>
+
+          <div className="border-t" />
+
+          <section>
+            <h3 className="text-lg font-medium mb-4">パスワード変更</h3>
+            <PasswordForm onSuccess={handlePasswordSuccess} />
+          </section>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -1,0 +1,255 @@
+import * as React from "react"
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return (
+    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  )
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return (
+    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "text-muted-foreground ml-auto text-xs tracking-widest",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -49,12 +49,14 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     jwt({ token, user }) {
       if (user) {
         token.id = user.id
+        token.name = user.name
       }
       return token
     },
     session({ session, token }) {
       if (session.user && token.id) {
         session.user.id = token.id
+        session.user.name = token.name as string | null
       }
       return session
     },

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -46,10 +46,19 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     }),
   ],
   callbacks: {
-    jwt({ token, user }) {
+    jwt({ token, user, trigger, session }) {
       if (user) {
         token.id = user.id
         token.name = user.name
+      }
+      // updateSession()からの更新を処理
+      if (trigger === 'update' && session) {
+        if (session.name !== undefined) {
+          token.name = session.name
+        }
+        if (session.email !== undefined) {
+          token.email = session.email
+        }
       }
       return token
     },

--- a/lib/validations/auth.ts
+++ b/lib/validations/auth.ts
@@ -5,7 +5,11 @@ export const signupSchema = z
     email: z.string().email('有効なメールアドレスを入力してください'),
     password: z
       .string()
-      .min(8, 'パスワードは8文字以上で入力してください'),
+      .min(8, 'パスワードは8文字以上で入力してください')
+      .regex(
+        /^(?=.*[a-zA-Z])(?=.*\d)/,
+        'パスワードには英字と数字を含めてください'
+      ),
     confirmPassword: z.string(),
   })
   .refine((data) => data.password === data.confirmPassword, {

--- a/lib/validations/auth.ts
+++ b/lib/validations/auth.ts
@@ -2,7 +2,10 @@ import { z } from 'zod'
 
 export const signupSchema = z
   .object({
-    email: z.string().email('有効なメールアドレスを入力してください'),
+    email: z
+      .string()
+      .trim()
+      .email('有効なメールアドレスを入力してください'),
     password: z
       .string()
       .min(8, 'パスワードは8文字以上で入力してください')
@@ -18,7 +21,10 @@ export const signupSchema = z
   })
 
 export const loginSchema = z.object({
-  email: z.string().email('有効なメールアドレスを入力してください'),
+  email: z
+    .string()
+    .trim()
+    .email('有効なメールアドレスを入力してください'),
   password: z.string().min(1, 'パスワードを入力してください'),
 })
 

--- a/lib/validations/profile.ts
+++ b/lib/validations/profile.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod'
+
+export const updateProfileSchema = z.object({
+  name: z.string().optional().nullable(),
+  email: z.string().email('有効なメールアドレスを入力してください'),
+})
+
+export const changePasswordSchema = z
+  .object({
+    currentPassword: z.string().min(1, '現在のパスワードを入力してください'),
+    newPassword: z
+      .string()
+      .min(8, 'パスワードは8文字以上で入力してください')
+      .regex(
+        /^(?=.*[a-zA-Z])(?=.*\d)/,
+        'パスワードには英字と数字を含めてください'
+      ),
+    confirmNewPassword: z.string(),
+  })
+  .refine((data) => data.newPassword === data.confirmNewPassword, {
+    message: '新しいパスワードが一致しません',
+    path: ['confirmNewPassword'],
+  })
+
+export type UpdateProfileInput = z.infer<typeof updateProfileSchema>
+export type ChangePasswordInput = z.infer<typeof changePasswordSchema>

--- a/lib/validations/profile.ts
+++ b/lib/validations/profile.ts
@@ -5,6 +5,18 @@ export const updateProfileSchema = z.object({
   email: z.string().email('有効なメールアドレスを入力してください'),
 })
 
+// 正規化用のヘルパー関数（Server Actionで使用）
+export function normalizeProfileInput(data: UpdateProfileInput): {
+  name: string | null
+  email: string
+} {
+  const name = data.name?.trim()
+  return {
+    name: name && name !== '' ? name : null,
+    email: data.email.trim().toLowerCase(),
+  }
+}
+
 export const changePasswordSchema = z
   .object({
     currentPassword: z.string().min(1, '現在のパスワードを入力してください'),

--- a/lib/validations/profile.ts
+++ b/lib/validations/profile.ts
@@ -2,18 +2,33 @@ import { z } from 'zod'
 
 export const updateProfileSchema = z.object({
   name: z.string().optional().nullable(),
-  email: z.string().email('有効なメールアドレスを入力してください'),
+  email: z
+    .string()
+    .trim()
+    .email('有効なメールアドレスを入力してください'),
 })
 
 // 正規化用のヘルパー関数（Server Actionで使用）
+// name未指定時はundefinedを返し、更新対象から外せるようにする
 export function normalizeProfileInput(data: UpdateProfileInput): {
-  name: string | null
+  name: string | null | undefined
   email: string
 } {
-  const name = data.name?.trim()
+  // nameが未指定（undefined）の場合はundefinedを維持
+  // null または 空文字の場合はnullに正規化
+  // 有効な文字列の場合はtrimして返す
+  let name: string | null | undefined
+  if (data.name === undefined) {
+    name = undefined
+  } else if (data.name === null || data.name.trim() === '') {
+    name = null
+  } else {
+    name = data.name.trim()
+  }
+
   return {
-    name: name && name !== '' ? name : null,
-    email: data.email.trim().toLowerCase(),
+    name,
+    email: data.email.toLowerCase(), // trimはスキーマで実行済み
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-select": "^2.2.6",
@@ -3119,6 +3120,76 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-focus-guards": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
@@ -3237,6 +3308,87 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -3500,6 +3652,78 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",


### PR DESCRIPTION
## Summary
- ヘッダーのユーザーメニューからプロフィール編集ダイアログを開く機能を追加
- ユーザーネーム、メールアドレス、パスワードの変更が可能
- 変更後はブラウザ更新なしでUIに即座に反映
- メール正規化を全経路（サインアップ/ログイン/プロフィール更新）で統一

## Changes
- DropdownMenuコンポーネントを追加（shadcn/ui）
- プロフィール編集用のバリデーションスキーマとServer Actionsを追加
- BasicInfoForm、PasswordForm、ProfileDialogコンポーネントを追加
- UserMenuコンポーネントを追加（ログアウト機能統合）
- P2002エラー（一意制約違反）の適切なハンドリング
- セッション即時更新によるUI反映
- 新規登録のパスワードバリデーション強化（英数字必須）

## Codex Review
- [x] Codex MCPによるコードレビュー完了
- [x] 全ての指摘事項を修正済み

## Test Plan
- [x] テストが全てパスする（272テスト）
- [x] 新規テストを追加した
- [x] lint/型エラーがない

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)